### PR TITLE
Fix poverty list not adding/removing the right RPC

### DIFF
--- a/src/health/check.rs
+++ b/src/health/check.rs
@@ -13,7 +13,6 @@ use tokio::{
     time::{
         sleep,
         timeout,
-        Instant,
     },
 };
 
@@ -60,8 +59,8 @@ async fn check(
     escape_poverty(
         &rpc_list,
         poverty_list,
-        agreed_head,
         (*ttl).try_into().unwrap(),
+        agreed_head,
     )
     .await?;
     println!("rpc_list len: {:?}", rpc_list.read().unwrap().len());
@@ -186,8 +185,12 @@ async fn escape_poverty(
     let mut poverty_list_guard = poverty_list.write().unwrap();
     let mut rpc_list_guard = rpc_list.write().unwrap();
 
+    println!("agreed_head: {:?}", agreed_head);
+
     for head_result in poverty_heads {
-        if head_result.reported_head == agreed_head {
+        println!("head_result: {:?}", head_result.reported_head);
+
+        if head_result.reported_head >= agreed_head {
             // Move the RPC from the poverty list to the rpc list
             rpc_list_guard.push(poverty_list_guard[head_result.rpc_list_index].clone());
 

--- a/src/health/check.rs
+++ b/src/health/check.rs
@@ -33,7 +33,11 @@ pub async fn health_check(
     loop {
         sleep(Duration::from_millis(health_check_ttl)).await;
         check(&rpc_list, &poverty_list, &ttl).await?;
+        
+        println!("\nrpc_list len: {:?}", rpc_list.read().unwrap().len());
+        println!("poverty_list len: {:?}\n", poverty_list.read().unwrap().len());
         get_safe_block(&rpc_list, &finalized, health_check_ttl).await?;
+
     }
 }
 
@@ -191,8 +195,13 @@ async fn escape_poverty(
         println!("head_result: {:?}", head_result.reported_head);
 
         if head_result.reported_head >= agreed_head {
+            println!("RPC escaped poverty! 🗣️🔥🔥🔥");
+
+            let mut rpc = poverty_list_guard[head_result.rpc_list_index].clone();
+            rpc.status.is_erroring = false;
+
             // Move the RPC from the poverty list to the rpc list
-            rpc_list_guard.push(poverty_list_guard[head_result.rpc_list_index].clone());
+            rpc_list_guard.push(rpc);
 
             // Remove the RPC from the poverty list
             poverty_list_guard[head_result.rpc_list_index]

--- a/src/health/check.rs
+++ b/src/health/check.rs
@@ -9,12 +9,12 @@ use std::sync::{
 use std::time::Duration;
 
 use tokio::{
+    sync::mpsc,
     time::{
-        Instant,
         sleep,
         timeout,
+        Instant,
     },
-    sync::mpsc,
 };
 
 #[derive(Debug, Default)]
@@ -112,7 +112,9 @@ async fn head_check(
             };
 
             // Send the result to the main thread through the channel
-            tx.send(head_result).await.expect("head check: Channel send error");
+            tx.send(head_result)
+                .await
+                .expect("head check: Channel send error");
         };
 
         rpc_futures.push(rpc_future);
@@ -184,13 +186,15 @@ async fn escape_poverty(
     let mut poverty_list_guard = poverty_list.write().unwrap();
     let mut rpc_list_guard = rpc_list.write().unwrap();
 
-    for head_result in provert_heads {
+    for head_result in poverty_heads {
         if head_result.reported_head == agreed_head {
             // Move the RPC from the poverty list to the rpc list
             rpc_list_guard.push(poverty_list_guard[head_result.rpc_list_index].clone());
 
             // Remove the RPC from the poverty list
-            poverty_list_guard[head_result.rpc_list_index].status.is_erroring = false;
+            poverty_list_guard[head_result.rpc_list_index]
+                .status
+                .is_erroring = false;
         }
     }
 

--- a/src/health/check.rs
+++ b/src/health/check.rs
@@ -14,6 +14,7 @@ use tokio::{
         sleep,
         timeout,
     },
+    sync::mpsc,
 };
 
 // call check n a loop
@@ -71,48 +72,58 @@ async fn head_check(
     ttl: u128,
 ) -> Result<Vec<u64>, Box<dyn std::error::Error>> {
     let len = rpc_list.read().unwrap().len();
+    // If len == 0 return empty Vec
+    if len == 0 {
+        return Ok(Vec::<u64>::new());
+    }
+
     let mut heads = Vec::new();
-    let mut threads = Vec::new();
 
     // Create a vector to store the futures of all RPC requests
     let mut rpc_futures = Vec::new();
 
+    // Create a channel for collecting results in order
+    let (tx, mut rx) = mpsc::channel(len);
+
     // Iterate over all RPCs
     for i in 0..len {
         let rpc_clone = rpc_list.read().unwrap()[i].clone();
+        let tx = tx.clone(); // Clone the sender for this RPC
 
         // Spawn a future for each RPC
         let rpc_future = async move {
             let a = rpc_clone.block_number();
             let result = timeout(Duration::from_millis(ttl.try_into().unwrap()), a).await;
 
-            match result {
+            let head = match result {
                 Ok(response) => response.unwrap_or(0), // Handle timeout as 0
                 Err(_) => 0,                           // Handle timeout as 0
-            }
+            };
+
+            // Send the result to the main thread through the channel
+            tx.send(head).await.expect("Channel send error");
         };
 
         rpc_futures.push(rpc_future);
     }
 
-    // Wait for all RPC futures concurrently and collect their results
+    // Wait for all RPC futures concurrently
     for rpc_future in rpc_futures {
-        let result = tokio::spawn(rpc_future);
-        threads.push(result);
+        tokio::spawn(rpc_future);
     }
 
-    // Collect the results using tokio::select!
+    // Collect the results in order from the channel
     for _ in 0..len {
-        select! {
-            result = threads.pop().unwrap() => {
-                heads.push(result.unwrap());
-            }
+        if let Some(result) = rx.recv().await {
+            heads.push(result);
         }
     }
+
     println!("Heads: {:?}", heads);
 
     Ok(heads)
 }
+
 
 // Add unresponsive/erroring RPCs to the poverty list
 fn make_poverty(

--- a/src/health/check.rs
+++ b/src/health/check.rs
@@ -184,19 +184,18 @@ async fn escape_poverty(
     let mut poverty_list_guard = poverty_list.write().unwrap();
     let mut rpc_list_guard = rpc_list.write().unwrap();
 
-    let mut i = 0;
-    while i < poverty_list_guard.len() {
-        if poverty_heads[i] >= agreed_head {
-            // Remove from poverty list and add to rpc list
-            let mut removed_rpc = poverty_list_guard.remove(i);
-            // Remove erroring status from the rpc
-            removed_rpc.status.is_erroring = false;
+    for head_result in provert_heads {
+        if head_result.reported_head == agreed_head {
+            // Move the RPC from the poverty list to the rpc list
+            rpc_list_guard.push(poverty_list_guard[head_result.rpc_list_index].clone());
 
-            rpc_list_guard.push(removed_rpc);
-        } else {
-            i += 1; // Move to the next element if not removed
+            // Remove the RPC from the poverty list
+            poverty_list_guard[head_result.rpc_list_index].status.is_erroring = false;
         }
     }
+
+    // Only retain erroring RPCs
+    poverty_list_guard.retain(|rpc| rpc.status.is_erroring == true);
 
     Ok(())
 }


### PR DESCRIPTION
The poverty list was not getting updated properly because heads pushed results onto the heads vec as they came in, and not their order in rpc_list.

This PR fixes this, as well as some other bugs like RPCs not getting moved when they should have been moved.