### PR TITLE
fix(balancer): Insert content-type header if not set to json

### DIFF
--- a/example_config.toml
+++ b/example_config.toml
@@ -12,7 +12,7 @@ ma_length = 100
 sort_on_startup = true
 # Enable health checking
 health_check = true
-# Enable header checking
+# Enable content type header checking
 header_check = true
 # Acceptable time to wait for a response in ms
 ttl = 30

--- a/example_config.toml
+++ b/example_config.toml
@@ -12,6 +12,8 @@ ma_length = 100
 sort_on_startup = true
 # Enable health checking
 health_check = true
+# Enable header checking
+header_check = true
 # Acceptable time to wait for a response in ms
 ttl = 30
 # How many times to retry a request before giving up

--- a/src/balancer/accept_http.rs
+++ b/src/balancer/accept_http.rs
@@ -284,14 +284,10 @@ async fn forward_body(
     Option<usize>,
 ) {
     // Check if body has application/json
+    let mut tx = tx;
     if tx.headers().get("content-type") != Some(&HeaderValue::from_static("application/json")) {
-        return (
-            Ok(hyper::Response::builder()
-                .status(400)
-                .body(Full::new(Bytes::from("Improper content-type header")))
-                .unwrap()),
-            None,
-        );
+        let headers = tx.headers_mut();
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
     }
 
     // Convert incoming body to serde value

--- a/src/balancer/accept_http.rs
+++ b/src/balancer/accept_http.rs
@@ -284,8 +284,10 @@ async fn forward_body(
     Result<hyper::Response<Full<Bytes>>, Infallible>,
     Option<usize>,
 ) {
+    // Check if body has application/json
+    //
+    // Can be toggled via the config. Should be on if we want blutgang to be JSON-RPC compliant.
     if params.header_check {
-        // Check if body has application/json
         if tx.headers().get("content-type") != Some(&HeaderValue::from_static("application/json")) {
             return (
                 Ok(hyper::Response::builder()

--- a/src/balancer/accept_http.rs
+++ b/src/balancer/accept_http.rs
@@ -433,7 +433,7 @@ pub async fn accept_request(
     //
     // Also handle cache insertions.
     let time = Instant::now();
-    let (response, rpc_position) = forward_body(
+    (response, rpc_position) = forward_body(
         tx,
         &connection_params.rpc_list_rwlock,
         &connection_params.channels.finalized_rx,

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -19,7 +19,7 @@ macro_rules! log_info {
         let message = format!($fmt, $($arg)*);
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(6, &message);
         }
         println!("\x1b[35mInfo:\x1b[0m {}", message)
@@ -40,7 +40,7 @@ macro_rules! log_wrn {
         let message = format!($fmt, $($arg)*);
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(4, &message);
         }
         println!("\x1b[93mWrn:\x1b[0m {}", message)
@@ -61,7 +61,7 @@ macro_rules! log_err {
         let message = format!($fmt, $($arg)*);
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(3, &message);
         }
         println!("\x1b[31mErr:\x1b[0m {}", message)

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -27,7 +27,7 @@ macro_rules! log_info {
     ($fmt:expr) => {
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(6, $fmt);
         }
         println!(concat!("\x1b[35mInfo:\x1b[0m ", $fmt))
@@ -48,7 +48,7 @@ macro_rules! log_wrn {
     ($fmt:expr) => {
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(4, $fmt);
         }
         println!(concat!("\x1b[93mWrn:\x1b[0m ", $fmt))
@@ -69,7 +69,7 @@ macro_rules! log_err {
     ($fmt:expr) => {
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(3, $fmt);
         }
         println!(concat!("\x1b[31mErr:\x1b[0m ", $fmt))

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -63,6 +63,7 @@ pub struct Settings {
     pub do_clear: bool,
     pub address: SocketAddr,
     pub health_check: bool,
+    pub header_check: bool,
     pub ttl: u128,
     pub expected_block_time: u64,
     pub supress_rpc_check: bool,
@@ -80,6 +81,7 @@ impl Default for Settings {
             do_clear: false,
             address: "127.0.0.1:3000".parse::<SocketAddr>().unwrap(),
             health_check: false,
+            header_check: true,
             ttl: 1000,
             expected_block_time: 12500,
             supress_rpc_check: true,
@@ -167,6 +169,11 @@ impl Settings {
             .expect("\x1b[31mErr:\x1b[0m Missing health_check toggle!")
             .as_bool()
             .expect("\x1b[31mErr:\x1b[0m Could not parse health_check as bool!");
+        let header_check = blutgang_table
+            .get("header_check")
+            .expect("\x1b[31mErr:\x1b[0m Missing header_check toggle!")
+            .as_bool()
+            .expect("\x1b[31mErr:\x1b[0m Could not parse header_check as bool!");
         let ttl = blutgang_table
             .get("ttl")
             .expect("\x1b[31mErr:\x1b[0m Missing ttl!")
@@ -402,6 +409,7 @@ impl Settings {
             do_clear,
             address,
             health_check,
+            header_check,
             ttl,
             expected_block_time,
             max_retries,
@@ -490,6 +498,7 @@ impl Settings {
             .flush_every_ms(Some(flush_every_ms));
 
         let health_check = matches.get_occurrences::<String>("health_check").is_some();
+        let header_check = matches.get_occurrences::<String>("header_check").is_some();
 
         let ttl = matches
             .get_one::<String>("ttl")
@@ -549,6 +558,7 @@ impl Settings {
             do_clear: clear,
             address,
             health_check,
+            header_check,
             ttl,
             supress_rpc_check,
             expected_block_time,

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -45,7 +45,7 @@ pub struct Rpc {
 // For example, if we have a URL: https://eth-mainnet.g.alchemy.com/v2/api-key
 // as input, we output: https://eth-mainnet.g.alchemy.com/
 fn sanitize_url(url: &str) -> Result<String, url::ParseError> {
-    let parsed_url = Url::parse(&url)?;
+    let parsed_url = Url::parse(url)?;
 
     // Build a new URL with the scheme, host, and port (if any), but without the path or query
     let sanitized = Url::parse(&format!(


### PR DESCRIPTION
If `Content-type: application/json` is not set, blutgang will fail and reject the request. Instead of this, let's just set the appropriate header.