### PR TITLE
Prometheus logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /default.sled
 .local-history
 src/config/test_metrics.json
+Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /config.toml
 /.env
 /default.sled
+.local-history
+src/config/test_metrics.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +109,12 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 
 [[package]]
 name = "autocfg"
@@ -169,6 +181,7 @@ dependencies = [
 name = "blutgang"
 version = "0.3.2"
 dependencies = [
+ "atomic_refcell",
  "blake3",
  "chrono",
  "clap",
@@ -181,6 +194,11 @@ dependencies = [
  "jemallocator",
  "jsonwebtoken",
  "memchr",
+ "metrics",
+ "metrics-prometheus",
+ "once_cell",
+ "prometheus",
+ "prometheus-metric-storage",
  "rand",
  "reqwest",
  "serde",
@@ -459,7 +477,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -549,7 +567,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -682,6 +700,15 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1098,6 +1125,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "metrics"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd71d9db2e4287c3407fa04378b8c2ee570aebe0854431562cdd89ca091854f4"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-prometheus"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e1316f9ef05b91f4d0e0a0da5b620ba919d336280b83b36be096b86c030fdd"
+dependencies = [
+ "arc-swap",
+ "metrics",
+ "metrics-util",
+ "once_cell",
+ "prometheus",
+ "sealed",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece71ab046dcf45604e573329966ec1db5ff4b81cfa170a924ff4c959ab5451a"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "metrics",
+ "num_cpus",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,7 +1290,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1253,7 +1319,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -1265,9 +1341,22 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.4.1",
+ "smallvec",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1303,7 +1392,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1325,6 +1414,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1439,49 @@ checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.1",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "prometheus-metric-storage"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3282447ea0b07baa9011e45de96794c5963db0162c1001d2867750715d63ff14"
+dependencies = [
+ "lazy_static",
+ "prometheus",
+ "prometheus-metric-storage-derive",
+]
+
+[[package]]
+name = "prometheus-metric-storage-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239221aa10cd35277c58b8f6509280b2613321760b49584d7a7351a6aacb6963"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
@@ -1389,6 +1527,15 @@ name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -1497,6 +1644,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sealed"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a8caec23b7800fb97971a1c6ae365b6239aaeddfb934d6265f8505e795699d"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,7 +1695,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1637,7 +1796,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
  "zstd",
 ]
 
@@ -1674,6 +1833,17 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1757,7 +1927,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1831,7 +2001,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2114,7 +2284,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -2148,7 +2318,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2375,7 +2545,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "blake3",
  "chrono",
  "clap",
+ "crossbeam-channel",
  "futures",
  "futures-util",
  "http-body-util",
@@ -206,6 +207,7 @@ dependencies = [
  "simd-json",
  "sled",
  "systemd",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -342,6 +344,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1912,18 +1923,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "blutgang"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "atomic_refcell",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ metrics = "0.22.1"
 once_cell = "1.19.0"
 prometheus-metric-storage = "0.5.0"
 atomic_refcell = "0.1.13"
-
 # Maxperf profile for absolute maximum performance
 # Only use for builds that are going to get used by end users
 [profile.maxperf]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,11 @@ tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 futures-util = "0.3.29"
 systemd = { version = "0.10.0", optional = true }
 dogstatsd = { version = "0.11.1", optional = true }
-metrics-prometheus = {version = "0.6.0", optional = true}
+metrics-prometheus = { version = "0.6.0", optional = true }
 metrics-exporter-statsd = "0.7.0"
 prometheus = "0.13.3"
+tracing-test = "0.2.4"
+metrics = "0.22.1"
 
 # Maxperf profile for absolute maximum performance
 # Only use for builds that are going to get used by end users
@@ -66,4 +68,5 @@ selection-weighed-round-robin = [] # default algo
 selection-random = [] # optional random algo
 old-weighted-round-robin = [] # old algo, does not account for max per second
 systemd = ["dep:systemd"]
+metrics-prometheus = ["dep:metrics-prometheus"]
 # add your own below

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ once_cell = "1.19.0"
 prometheus-metric-storage = "0.5.0"
 atomic_refcell = "0.1.13"
 crossbeam-channel = "0.5.12"
+thiserror = "1.0.58"
 # Maxperf profile for absolute maximum performance
 # Only use for builds that are going to get used by end users
 [profile.maxperf]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blutgang"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["makemake <vukasin@gostovic.me>, Rainshower Labs, contributors"]
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 futures-util = "0.3.29"
 systemd = { version = "0.10.0", optional = true }
 metrics-prometheus = { version = "0.6.0", optional = true }
-metrics-exporter-statsd = "0.7.0"
 prometheus = "0.13.3"
 metrics = "0.22.1"
 once_cell = "1.19.0"
 prometheus-metric-storage = "0.5.0"
+atomic_refcell = "0.1.13"
 
 # Maxperf profile for absolute maximum performance
 # Only use for builds that are going to get used by end users

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ tungstenite = "0.20.1"
 tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 futures-util = "0.3.29"
 systemd = { version = "0.10.0", optional = true }
+dogstatsd = { version = "0.11.1", optional = true }
+metrics-prometheus = {version = "0.6.0", optional = true}
+metrics-exporter-statsd = "0.7.0"
+prometheus = "0.13.3"
 
 # Maxperf profile for absolute maximum performance
 # Only use for builds that are going to get used by end users
@@ -52,6 +56,8 @@ incremental = false
 # Optional Blutgang features
 [features]
 journald = ["systemd"]
+dogstatd = ["dogstatsd"]
+prometheusd = ["metrics-prometheus"]
 default = ["selection-weighed-round-robin"]
 xxhash = ["xxhash-rust"] # 4x faster hashing but potentially less secure
 no-cache = [] # enable this to disable caching

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ metrics = "0.22.1"
 once_cell = "1.19.0"
 prometheus-metric-storage = "0.5.0"
 atomic_refcell = "0.1.13"
+crossbeam-channel = "0.5.12"
 # Maxperf profile for absolute maximum performance
 # Only use for builds that are going to get used by end users
 [profile.maxperf]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,10 @@ tungstenite = "0.20.1"
 tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 futures-util = "0.3.29"
 systemd = { version = "0.10.0", optional = true }
-dogstatsd = { version = "0.11.1", optional = true }
 metrics-prometheus = { version = "0.6.0", optional = true }
 metrics-exporter-statsd = "0.7.0"
 prometheus = "0.13.3"
-tracing-test = "0.2.4"
 metrics = "0.22.1"
-atomic_refcell = "0.1.13"
 once_cell = "1.19.0"
 prometheus-metric-storage = "0.5.0"
 
@@ -61,7 +58,6 @@ incremental = false
 # Optional Blutgang features
 [features]
 journald = ["systemd"]
-dogstatd = ["dogstatsd"]
 prometheusd = ["metrics-prometheus"]
 default = ["selection-weighed-round-robin"]
 xxhash = ["xxhash-rust"] # 4x faster hashing but potentially less secure

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ metrics-exporter-statsd = "0.7.0"
 prometheus = "0.13.3"
 tracing-test = "0.2.4"
 metrics = "0.22.1"
+atomic_refcell = "0.1.13"
+once_cell = "1.19.0"
+prometheus-metric-storage = "0.5.0"
 
 # Maxperf profile for absolute maximum performance
 # Only use for builds that are going to get used by end users

--- a/example_config.toml
+++ b/example_config.toml
@@ -12,6 +12,8 @@ ma_length = 100
 sort_on_startup = true
 # Enable health checking
 health_check = true
+# Enable content type header checking
+header_check = true
 # Acceptable time to wait for a response in ms
 ttl = 30
 # How many times to retry a request before giving up

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,9 @@
         pkgs = import nixpkgs {
           inherit system overlays;
         };
-      cargoMeta = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-      in {
+        cargoMeta = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      in
+      {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = cargoMeta.package.name;
           version = cargoMeta.package.version;
@@ -33,7 +34,6 @@
               extensions = [ "rust-src" "rustfmt-preview" "rust-analyzer" ];
             })
           ];
-
           cargoBuildFlags = [ "--profile maxperf" ];
         };
 
@@ -43,8 +43,10 @@
             pkg-config
             openssl
             systemd
-            (rust-bin.stable.latest.default.override { 
-              extensions = [ "rust-src" "rustfmt-preview" "rust-analyzer"];
+            clang
+            gdb
+            (rust-bin.stable.latest.default.override {
+              extensions = [ "rust-src" "rustfmt-preview" "rust-analyzer" ];
             })
           ];
 
@@ -53,9 +55,13 @@
             export RUSTC_WRAPPER=$(which sccache)
             export OLD_PS1="$PS1" # Preserve the original PS1
             export PS1="nix-shell:blutgang $PS1" # Customize this line as needed
+
+            # Set NIX_LD and NIX_LD_LIBRARY_PATH for rust-analyzer
+            export NIX_LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [ pkgs.glibc pkgs.gcc-unwrapped.lib ]}"
+            export NIX_LD="${pkgs.stdenv.cc}/nix-support/dynamic-linker"
           '';
 
-          # reser PS1
+          # reset ps1
           shellExitHook = ''
             export PS1="$OLD_PS1"
           '';

--- a/prom/Dockerfile
+++ b/prom/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus:v2.16.0
+ADD prometheus.yml /etc/prometheus/prometheus.yml

--- a/prom/prometheus.yml
+++ b/prom/prometheus.yml
@@ -1,0 +1,13 @@
+
+global:
+  scrape_interval:     5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'service-collector'
+    static_configs:
+      - targets: ['localhost:8080']

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,6 @@ pkgs.mkShell {
     pkgs.pkg-config
     pkgs.openssl
     pkgs.systemdLibs
-    pkgs.cargo2nix
   ];
 
   shellHook = ''

--- a/src/admin/liveready.rs
+++ b/src/admin/liveready.rs
@@ -1,0 +1,478 @@
+use std::{
+    convert::Infallible,
+    sync::{
+        Arc,
+        RwLock,
+    },
+};
+
+use http_body_util::Full;
+
+use tokio::sync::{
+    mpsc,
+    oneshot,
+};
+
+use hyper::body::Bytes;
+
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
+pub enum ReadinessState {
+    Ready,
+    #[default]
+    Setup,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
+pub enum HealthState {
+    #[default]
+    Healthy, // Everything nominal
+    MissingRpcs, // Some RPCs are not following the head but otherwise ok
+    Unhealthy,   // Nothing works
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
+pub struct LiveReady {
+    readiness: ReadinessState,
+    health: HealthState,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum LiveReadyUpdate {
+    Readiness(ReadinessState),
+    Health(HealthState),
+}
+
+// These 2 are used to send and receive updates related to the current
+// health of blutgang.
+pub type LiveReadyUpdateRecv = mpsc::Receiver<LiveReadyUpdate>;
+pub type LiveReadyUpdateSnd = mpsc::Sender<LiveReadyUpdate>;
+
+// These are used to request/return updates about health
+// pub type LiveReadyRecv = oneshot::Receiver<LiveReady>;
+pub type LiveReadySnd = oneshot::Sender<LiveReady>;
+
+pub type LiveReadyRequestRecv = mpsc::Receiver<LiveReadySnd>;
+pub type LiveReadyRequestSnd = mpsc::Sender<LiveReadySnd>;
+
+// Macros to make returning statuses less ugly in code
+macro_rules! ok {
+    () => {
+        Ok(hyper::Response::builder()
+            .status(200)
+            .body(Full::new(Bytes::from("OK")))
+            .unwrap())
+    };
+}
+
+macro_rules! partial_ok {
+    () => {
+        Ok(hyper::Response::builder()
+            .status(202)
+            .body(Full::new(Bytes::from("RPC")))
+            .unwrap())
+    };
+}
+
+macro_rules! nok {
+    () => {
+        Ok(hyper::Response::builder()
+            .status(503)
+            .body(Full::new(Bytes::from("NOK")))
+            .unwrap())
+    };
+}
+
+// Listen for liveness update messages and update the current status accordingly
+async fn liveness_listener(
+    mut liveness_receiver: LiveReadyUpdateRecv,
+    liveness_status: Arc<RwLock<LiveReady>>,
+) {
+    while let Some(update) = liveness_receiver.recv().await {
+        match update {
+            LiveReadyUpdate::Readiness(state) => {
+                let mut liveness = liveness_status.write().unwrap();
+                liveness.readiness = state;
+            }
+            LiveReadyUpdate::Health(state) => {
+                let mut liveness = liveness_status.write().unwrap();
+                liveness.health = state;
+            }
+        }
+    }
+}
+
+// Receives requests about current status updates and returns the current liveness
+async fn liveness_request_processor(
+    mut liveness_request_receiver: LiveReadyRequestRecv,
+    liveness_status: Arc<RwLock<LiveReady>>,
+) {
+    loop {
+        while let Some(incoming) = liveness_request_receiver.recv().await {
+            let current_status = *liveness_status.read().unwrap();
+            let _ = incoming.send(current_status);
+        }
+    }
+}
+
+// Monitor for new liveness updates and update the statuses accordingly.
+//
+// Also handles incoming requests about the current status.
+pub(in crate::r#admin) async fn liveness_monitor(
+    liveness_receiver: LiveReadyUpdateRecv,
+    liveness_request_receiver: LiveReadyRequestRecv,
+) {
+    let liveness_status = Arc::new(RwLock::new(LiveReady::default()));
+
+    // Spawn thread for listening and updating the current liveness status
+    let liveness_status_listener = liveness_status.clone();
+    tokio::spawn(liveness_listener(
+        liveness_receiver,
+        liveness_status_listener,
+    ));
+
+    // Listens to incoming requests about the current liveness
+    liveness_request_processor(liveness_request_receiver, liveness_status).await;
+}
+
+pub async fn accept_readiness_request(
+    liveness_request_sender: LiveReadyRequestSnd,
+) -> Result<hyper::Response<Full<Bytes>>, Infallible> {
+    let (tx, rx) = oneshot::channel();
+
+    let _ = liveness_request_sender.send(tx).await;
+
+    let rax = match rx.await {
+        Ok(v) => v,
+        Err(_) => {
+            return nok!();
+        }
+    };
+
+    if rax.readiness == ReadinessState::Ready {
+        return ok!();
+    }
+
+    nok!()
+}
+
+pub async fn accept_health_request(
+    liveness_request_sender: LiveReadyRequestSnd,
+) -> Result<hyper::Response<Full<Bytes>>, Infallible> {
+    let (tx, rx) = oneshot::channel();
+
+    let _ = liveness_request_sender.send(tx).await;
+
+    let rax = match rx.await {
+        Ok(v) => v,
+        Err(_) => {
+            return nok!();
+        }
+    };
+
+    match rax.health {
+        HealthState::Healthy => ok!(),
+        HealthState::MissingRpcs => partial_ok!(),
+        HealthState::Unhealthy => nok!(),
+    }
+}
+
+// Just a sink used to immediately discard request in cases where admin is disabled
+pub async fn liveness_update_sink(mut liveness_rx: LiveReadyUpdateRecv) {
+    loop {
+        while (liveness_rx.recv().await).is_some() {
+            continue;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Rpc;
+    use tokio::sync::{
+        mpsc,
+        oneshot,
+    };
+    use tokio::time::sleep;
+    use tokio::time::Duration;
+
+    #[tokio::test]
+    async fn test_liveness_listener_updates_status() {
+        let (update_snd, update_recv) = mpsc::channel(10);
+        let liveness_status = Arc::new(RwLock::new(LiveReady::default()));
+
+        // Simulate sending updates
+        let liveness_status_clone = liveness_status.clone();
+        tokio::spawn(async move {
+            liveness_listener(update_recv, liveness_status_clone).await;
+        });
+
+        update_snd
+            .send(LiveReadyUpdate::Readiness(ReadinessState::Ready))
+            .await
+            .unwrap();
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::MissingRpcs))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await; // Give time for async updates
+
+        assert_eq!(
+            liveness_status.read().unwrap().readiness,
+            ReadinessState::Ready
+        );
+        assert_eq!(
+            liveness_status.read().unwrap().health,
+            HealthState::MissingRpcs
+        );
+    }
+
+    #[tokio::test]
+    async fn test_accept_readiness_request_returns_correct_response() {
+        let (request_snd, request_recv) = mpsc::channel(1);
+        let liveness_status = Arc::new(RwLock::new(LiveReady {
+            readiness: ReadinessState::Ready,
+            health: HealthState::Healthy,
+        }));
+
+        tokio::spawn(liveness_request_processor(
+            request_recv,
+            liveness_status.clone(),
+        ));
+
+        let response = accept_readiness_request(request_snd.clone()).await.unwrap();
+        assert_eq!(response.status(), 200);
+
+        // Testing with readiness set to Setup
+        let (tx, _rx) = oneshot::channel();
+        request_snd.send(tx).await.unwrap();
+        liveness_status.write().unwrap().readiness = ReadinessState::Setup;
+        let response = accept_readiness_request(request_snd).await.unwrap();
+        assert_eq!(response.status(), 503);
+    }
+
+    #[tokio::test]
+    async fn test_accept_health_request_returns_correct_response() {
+        let (request_snd, request_recv) = mpsc::channel(1);
+        let liveness_status = Arc::new(RwLock::new(LiveReady {
+            readiness: ReadinessState::Ready,
+            health: HealthState::Healthy,
+        }));
+
+        tokio::spawn(liveness_request_processor(
+            request_recv,
+            liveness_status.clone(),
+        ));
+
+        // Test with healthy state
+        let response = accept_health_request(request_snd.clone()).await.unwrap();
+        assert_eq!(response.status(), 200);
+
+        // Test with MissingRpcs state
+        let (tx, _rx) = oneshot::channel();
+        request_snd.send(tx).await.unwrap();
+        liveness_status.write().unwrap().health = HealthState::MissingRpcs;
+        let response = accept_health_request(request_snd.clone()).await.unwrap();
+        assert_eq!(response.status(), 202);
+
+        // Test with Unhealthy state
+        let (tx, _rx) = oneshot::channel();
+        request_snd.send(tx).await.unwrap();
+        liveness_status.write().unwrap().health = HealthState::Unhealthy;
+        let response = accept_health_request(request_snd).await.unwrap();
+        assert_eq!(response.status(), 503);
+    }
+
+    #[tokio::test]
+    async fn test_liveness_update_sink_discards_updates() {
+        let (update_snd, update_recv) = mpsc::channel(10);
+
+        // Simulate a sink that discards updates
+        tokio::spawn(async move {
+            liveness_update_sink(update_recv).await;
+        });
+
+        update_snd
+            .send(LiveReadyUpdate::Readiness(ReadinessState::Ready))
+            .await
+            .unwrap();
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::MissingRpcs))
+            .await
+            .unwrap();
+
+        // No assertion here as we're testing the sink's ability to simply discard incoming messages
+        assert!(
+            true,
+            "Successfully discarded updates without affecting the test flow"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_and_request_liveness_status_concurrently() {
+        let (update_snd, update_recv) = mpsc::channel(10);
+        let (request_snd, request_recv) = mpsc::channel(10);
+        let liveness_status = Arc::new(RwLock::new(LiveReady::default()));
+        let liveness_status_clone = liveness_status.clone();
+
+        tokio::spawn(async move {
+            liveness_listener(update_recv, liveness_status_clone).await;
+        });
+        tokio::spawn(async move {
+            liveness_request_processor(request_recv, liveness_status).await;
+        });
+
+        // Send updates
+        update_snd
+            .send(LiveReadyUpdate::Readiness(ReadinessState::Ready))
+            .await
+            .unwrap();
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Unhealthy))
+            .await
+            .unwrap();
+
+        // Request status immediately after sending updates
+        let (response_tx, response_rx) = oneshot::channel();
+        request_snd.send(response_tx).await.unwrap();
+
+        // Ensure the status reflects the last update sent
+        let received_status = response_rx.await.expect("Failed to receive response");
+        assert_eq!(received_status.readiness, ReadinessState::Ready);
+        assert_eq!(received_status.health, HealthState::Unhealthy);
+
+        // Send another set of updates and request again
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Healthy))
+            .await
+            .unwrap();
+        let (new_response_tx, new_response_rx) = oneshot::channel();
+        request_snd.send(new_response_tx).await.unwrap();
+
+        let new_received_status = new_response_rx
+            .await
+            .expect("Failed to receive new response");
+        assert_eq!(new_received_status.health, HealthState::Healthy);
+
+        // Testing edge cases
+        // Sending None update (Shouldn't change the status)
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Healthy))
+            .await
+            .unwrap();
+        let (edge_response_tx, edge_response_rx) = oneshot::channel();
+        request_snd.send(edge_response_tx).await.unwrap();
+
+        let edge_received_status = edge_response_rx
+            .await
+            .expect("Failed to receive edge response");
+        assert_eq!(edge_received_status.readiness, ReadinessState::Ready);
+        assert_eq!(edge_received_status.health, HealthState::Healthy);
+    }
+
+    #[tokio::test]
+    async fn test_empty_updates_does_not_change_status() {
+        let (update_snd, update_recv) = mpsc::channel(1);
+        let liveness_status = Arc::new(RwLock::new(LiveReady {
+            readiness: ReadinessState::Ready,
+            health: HealthState::Healthy,
+        }));
+
+        let liveness_status_clone = liveness_status.clone();
+
+        tokio::spawn(async move {
+            liveness_listener(update_recv, liveness_status_clone).await;
+        });
+
+        // Intentionally not sending any updates
+        drop(update_snd);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await; // Give time for any potential updates
+
+        assert_eq!(
+            liveness_status.read().unwrap().readiness,
+            ReadinessState::Ready
+        );
+        assert_eq!(liveness_status.read().unwrap().health, HealthState::Healthy);
+    }
+
+    #[tokio::test]
+    async fn test_health_state_transitions() {
+        let rpc_list = Arc::new(RwLock::new(vec![Rpc::default(), Rpc::default()]));
+        let poverty_list = Arc::new(RwLock::new(Vec::new()));
+        let (update_snd, update_recv) = mpsc::channel(10);
+        let liveness_status = Arc::new(RwLock::new(LiveReady::default()));
+
+        let liveness_status_clone = liveness_status.clone();
+
+        tokio::spawn(async move {
+            liveness_listener(update_recv, liveness_status_clone).await;
+        });
+
+        // Force add RPCs to poverty list and send health update
+        let mut rpcs_in_poverty = rpc_list.write().unwrap().drain(..).collect::<Vec<_>>();
+        poverty_list.write().unwrap().append(&mut rpcs_in_poverty);
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Unhealthy))
+            .await
+            .unwrap();
+
+        // Check for Unhealthy status
+        sleep(Duration::from_millis(50)).await; // Allow for processing
+        assert_eq!(
+            liveness_status.read().unwrap().health,
+            HealthState::Unhealthy
+        );
+        assert!(rpc_list.read().unwrap().is_empty());
+        assert_eq!(poverty_list.read().unwrap().len(), 2);
+
+        // Remove RPCs from poverty list, simulate recovery, and send health update
+        let mut recovered_rpcs = poverty_list.write().unwrap().drain(..).collect::<Vec<_>>();
+        rpc_list.write().unwrap().append(&mut recovered_rpcs);
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Healthy))
+            .await
+            .unwrap();
+
+        // Check for Healthy status
+        sleep(Duration::from_millis(50)).await; // Allow for processing
+        assert_eq!(liveness_status.read().unwrap().health, HealthState::Healthy);
+        assert_eq!(rpc_list.read().unwrap().len(), 2);
+        assert!(poverty_list.read().unwrap().is_empty());
+
+        // Reverse the process: simulate RPCs failing again and moving back to poverty list
+        let mut rpcs_in_poverty_again = rpc_list.write().unwrap().drain(..).collect::<Vec<_>>();
+        poverty_list
+            .write()
+            .unwrap()
+            .append(&mut rpcs_in_poverty_again);
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Unhealthy))
+            .await
+            .unwrap();
+
+        // Check for Unhealthy status again
+        sleep(Duration::from_millis(50)).await; // Allow for processing
+        assert_eq!(
+            liveness_status.read().unwrap().health,
+            HealthState::Unhealthy
+        );
+        assert!(rpc_list.read().unwrap().is_empty());
+        assert_eq!(poverty_list.read().unwrap().len(), 2);
+
+        // Recover again and verify
+        let mut recovered_rpcs_again = poverty_list.write().unwrap().drain(..).collect::<Vec<_>>();
+        rpc_list.write().unwrap().append(&mut recovered_rpcs_again);
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Healthy))
+            .await
+            .unwrap();
+
+        // Final check for Healthy status
+        sleep(Duration::from_millis(50)).await; // Allow for processing
+        assert_eq!(liveness_status.read().unwrap().health, HealthState::Healthy);
+        assert_eq!(rpc_list.read().unwrap().len(), 2);
+        assert!(poverty_list.read().unwrap().is_empty());
+    }
+}

--- a/src/admin/methods.rs
+++ b/src/admin/methods.rs
@@ -1,10 +1,19 @@
+#[cfg(feature = "prometheusd")]
+use crate::config::system::{
+    MetricChannelCommand,
+    MetricReceiver,
+    MetricSender,
+    MetricsCommand,
+    MetricsError,
+    RegistryChannel,
+    RpcMetrics,
+    RpcMetricsSender,
+};
 use crate::{
     admin::error::AdminError,
     Rpc,
     Settings,
 };
-#[cfg(feature = "prometheusd")]
-use crate::config::system::{MetricsError, RegistryChannel, MetricReceiver, MetricSender, RpcMetrics, MetricChannelCommand, RpcMetricsSender, MetricsCommand};
 
 use std::{
     sync::{
@@ -134,7 +143,10 @@ async fn admin_flush_cache(cache: Arc<Db>) -> Result<Value, AdminError> {
 }
 
 #[cfg(feature = "prometheusd")]
-async fn admin_flush_metrics(channel: &RegistryChannel, tx: RpcMetricsSender) -> Result<(), MetricsError> {
+async fn admin_flush_metrics(
+    channel: &RegistryChannel,
+    tx: RpcMetricsSender,
+) -> Result<(), MetricsError> {
     let dt = Instant::now();
 
     let command = MetricsCommand::Flush(channel);

--- a/src/admin/methods.rs
+++ b/src/admin/methods.rs
@@ -3,6 +3,8 @@ use crate::{
     Rpc,
     Settings,
 };
+#[cfg(feature = "prometheusd")]
+use crate::config::system::{MetricsError, RegistryChannel, MetricReceiver, MetricSender, RpcMetrics, MetricChannelCommand, RpcMetricsSender, MetricsCommand};
 
 use std::{
     sync::{
@@ -128,8 +130,16 @@ async fn admin_flush_cache(cache: Arc<Db>) -> Result<Value, AdminError> {
         "jsonrpc": "2.0",
         "result": format!("Cache flushed in {:?}", time),
     });
-
     Ok(rx)
+}
+
+#[cfg(feature = "prometheusd")]
+async fn admin_flush_metrics(channel: &RegistryChannel, tx: RpcMetricsSender) -> Result<(), MetricsError> {
+    let dt = Instant::now();
+
+    let command = MetricsCommand::Flush(channel);
+    channel.on_flush(tx);
+    Ok(())
 }
 
 // Respond with the config we started blutgang with

--- a/src/admin/methods.rs
+++ b/src/admin/methods.rs
@@ -7,7 +7,6 @@ use crate::config::system::{
     MetricsError,
     RegistryChannel,
     RpcMetrics,
-    RpcMetricsSender,
 };
 use crate::{
     admin::error::AdminError,
@@ -145,12 +144,10 @@ async fn admin_flush_cache(cache: Arc<Db>) -> Result<Value, AdminError> {
 #[cfg(feature = "prometheusd")]
 async fn admin_flush_metrics(
     channel: &RegistryChannel,
-    tx: RpcMetricsSender,
+    tx: MetricSender,
 ) -> Result<(), MetricsError> {
     let dt = Instant::now();
 
-    let command = MetricsCommand::Flush(channel);
-    channel.on_flush(tx);
     Ok(())
 }
 

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -1,4 +1,5 @@
 mod accept;
 mod error;
 pub mod listener;
+pub mod liveready;
 mod methods;

--- a/src/balancer/selection/select.rs
+++ b/src/balancer/selection/select.rs
@@ -2,7 +2,7 @@ use crate::Rpc;
 use std::time::SystemTime;
 
 // Generic entry point fn to select the next rpc and return its position
-pub fn pick(list: &mut Vec<Rpc>) -> (Rpc, Option<usize>) {
+pub fn pick(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
     // If len is 1, return the only element
     if list.len() == 1 {
         return (list[0].clone(), Some(0));
@@ -35,7 +35,7 @@ pub fn argsort(data: &[Rpc]) -> Vec<usize> {
     not(feature = "selection-random"),
     not(feature = "old-weighted-round-robin"),
 ))]
-fn algo(list: &mut Vec<Rpc>) -> (Rpc, Option<usize>) {
+fn algo(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
     // Sort by latency
     let indices = argsort(list);
 
@@ -84,7 +84,7 @@ fn algo(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
     feature = "selection-weighed-round-robin",
     feature = "old-weighted-round-robin",
 ))]
-fn algo(list: &mut Vec<Rpc>) -> (Rpc, Option<usize>) {
+fn algo(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
     // Sort by latency
     let indices = argsort(list);
 

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -94,13 +94,13 @@ impl RpcMetrics {
 }
 
 //  #[cfg(feature = "prometheusd")]
-pub fn encode(registry: &prometheus::Registry) -> String {
-    use prometheus::Encoder;
-    let encoder = prometheus::TextEncoder::new();
-    let mut buffer = vec![];
-    encoder.encode(&registry.gather(), &mut buffer).unwrap();
-    String::from_utf8(buffer).unwrap()
-}
+// pub fn encode(registry: &prometheus::Registry) -> String {
+//     use prometheus::Encoder;
+//     let encoder = prometheus::TextEncoder::new();
+//     let mut buffer = vec![];
+//     encoder.encode(&registry.gather(), &mut buffer).unwrap();
+//     String::from_utf8(buffer).unwrap()
+// }
 
 #[cfg(feature = "journald")]
 pub fn log_journald(level: u32, message: &str) {
@@ -109,13 +109,13 @@ pub fn log_journald(level: u32, message: &str) {
 }
 
 // #[cfg(feature = "prometheusd")]
-pub fn get_storage_registry() -> &'static StorageRegistry {
-    &METRICS_REGISTRY
-}
-// #[cfg(feature = "prometheusd")]
-pub fn get_registry() -> &'static Registry {
-    get_storage_registry().registry()
-}
+// pub fn get_storage_registry() -> &'static StorageRegistry {
+//     &METRICS_REGISTRY
+// }
+// // #[cfg(feature = "prometheusd")]
+// pub fn get_registry() -> &'static Registry {
+//     get_storage_registry().registry()
+// }
 
 // #[cfg(feature = "prometheusd")]
 pub struct RpcMetricsReciever {
@@ -208,6 +208,19 @@ impl RegistryChannel {
         }
     }
 }
+
+// #[macro_export]
+// macro_rules! log_prometheus  {
+//     ($fmt:expr, $($arg:tt)*) => {
+//     let path = format!($fmt, $($arg)*);
+//      #[cfg(feature = "prometheusd")]
+//      {
+//         use $crate::config::system::{RpcMetrics, RegistryChannel};
+
+//          }
+//      }
+//     };
+// }_
 
 #[macro_export]
 macro_rules! log_info {

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -117,7 +117,7 @@ impl std::fmt::Debug for RpcMetricsSender {
 // #[cfg(feature = "prometheusd")]
 #[derive(Debug)]
 pub enum MetricsCommand<'a> {
-    Flush(&'a RegistryChannel),
+    Flush(),
     Channel(&'a RpcMetricsSender, &'a RpcMetricsReciever),
     PushLatency(&'a RpcMetrics, &'a RegistryChannel, &'a str, &'a str, f64),
     PushRequest(
@@ -194,7 +194,7 @@ async fn metrics_processor(
 // async fn metrics_encoder(mut metrics_rx: RpcMetricsReciever) -> String {
 //     let encoder = prometheus::TextEncoder::new();
 //     let mut buffer = vec![];
-//     encoder.encode().unwrap();
+//     encoder.
 // }
 
 pub async fn metrics_monitor(metrics_rx: RpcMetricsReciever, storage_registry: StorageRegistry) {

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -20,14 +20,16 @@ use prometheus_metric_storage::{
 };
 use simd_json::Object;
 
-
-use std::{collections::hash_map::HashMap, future::IntoFuture};
 use std::time::Duration;
+use std::{
+    collections::hash_map::HashMap,
+    future::IntoFuture,
+};
 use tokio::sync::{
     mpsc::{
+        unbounded_channel,
         UnboundedReceiver,
         UnboundedSender,
-        unbounded_channel
     },
     oneshot,
     Notify,
@@ -124,7 +126,7 @@ pub fn log_journald(level: u32, message: &str) {
 // #[cfg(feature = "prometheusd")]
 pub struct RpcMetricsReciever {
     inner: MetricReceiver,
-    name: &'static str,
+    pub name: &'static str,
     metrics: Option<RpcMetrics>,
 }
 // #[cfg(feature = "prometheusd")]
@@ -136,7 +138,7 @@ impl std::fmt::Debug for RpcMetricsReciever {
 // #[cfg(feature = "prometheusd")]
 pub struct RpcMetricsSender {
     inner: MetricSender,
-    name: &'static str,
+    pub name: &'static str,
     metrics: Option<RpcMetrics>,
 }
 // #[cfg(feature = "prometheusd")]
@@ -217,20 +219,20 @@ impl RegistryChannel {
     }
 }
 pub async fn push_latency(
-        metric: RpcMetrics,
-        path: &str,
-        method: &str,
-        dt: f64,
-        mut rx: RpcMetricsReciever,
-        tx: RpcMetricsSender,
-    ) {
-        let send = tx.inner.send(metric);
-        let recv = rx.inner.recv();
-        if let Ok(_) = send {
-            rx.metrics = Some(recv.await.unwrap());
-            rx.metrics.unwrap().push_latency(path, method, dt);
-        }
+    metric: RpcMetrics,
+    path: &str,
+    method: &str,
+    dt: f64,
+    mut rx: RpcMetricsReciever,
+    tx: RpcMetricsSender,
+) {
+    let send = tx.inner.send(metric);
+    let recv = rx.inner.recv();
+    if let Ok(_) = send {
+        rx.metrics = Some(recv.await.unwrap());
+        rx.metrics.unwrap().push_latency(path, method, dt);
     }
+}
 
 // #[macro_export]
 // macro_rules! log_prometheus  {

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -13,32 +13,44 @@ use prometheus_metric_storage::{MetricStorage, StorageRegistry};
 use std::time::Duration;
 
 //Some goofy Rust stuff
-#[cfg(feature = "prometheusd")]
+// #[cfg(feature = "prometheusd")]
 static METRICS_REGISTRY: Lazy<StorageRegistry> = Lazy::new(|| {
     let registry = Registry::new_custom(Some("blutgang".to_string()), None).unwrap();
     StorageRegistry::new(registry)
 });
-#[cfg(feature = "prometheusd")]
+// #[cfg(feature = "prometheusd")]
 #[derive(MetricStorage, Clone, Debug)]
 #[metric(subsystem = "rpc")]
 pub struct RpcMetrics {
     #[metric(labels("path", "method", "status"), help = "Total number of requests")]
-    requests_complete: prometheus::IntCounterVec,
-    #[metric(labels("path", "method"), help = "Duration of requests")]
+    requests: prometheus::IntCounterVec,
+    #[metric(labels("path", "method"), help = "latency of rpc calls")]
     duration: prometheus::HistogramVec,
 }
-#[cfg(feature = "prometheusd")]
+// #[cfg(feature = "prometheusd")]
 impl RpcMetrics {
     pub fn inst(registry: &StorageRegistry) -> Result<&Self, prometheus::Error> {
         RpcMetrics::instance(registry)
     }
     pub fn requests_complete(&self, path: &str, method: &str, status: &u16, duration: Duration) {
-        let dt = (duration.as_nanos() as f64) / 1_000_000_000.0;
-        self.requests_complete
+        let dt = duration.as_millis() as f64;
+        self.requests
             .with_label_values(&[path, method, &status.to_string()])
             .inc();
         self.duration.with_label_values(&[path, method]).observe(dt)
     }
+    pub fn push_latency(&self, path: &str, method: &str, dt: f64) {
+        self.duration.with_label_values(&[path, method]).observe(dt)
+    }
+}
+
+//  #[cfg(feature = "prometheusd")]
+pub fn encode(registry: &prometheus::Registry) -> String {
+    use prometheus::Encoder;
+    let encoder = prometheus::TextEncoder::new();
+    let mut buffer = vec![];
+    encoder.encode(&registry.gather(), &mut buffer).unwrap();
+    String::from_utf8(buffer).unwrap()
 }
 
 #[cfg(feature = "journald")]
@@ -47,58 +59,13 @@ pub fn log_journald(level: u32, message: &str) {
     journal::print(level, message);
 }
 
-#[cfg(feature = "statsd")]
-pub fn log_statsd(tags: &[str], message: &str) {
-    unimplemented!()
-}
-
-#[cfg(feature = "prometheusd")]
+// #[cfg(feature = "prometheusd")]
 pub fn get_storage_registry() -> &'static StorageRegistry {
     &METRICS_REGISTRY
 }
-
-#[cfg(feature = "prometheusd")]
+// #[cfg(feature = "prometheusd")]
 pub fn get_registry() -> &'static Registry {
     get_storage_registry().registry()
-}
-
-#[cfg(feature = "prometheusd")]
-pub fn recorder_init() -> Result<metrics_prometheus::Recorder, prometheus::Error> {
-    use metrics_prometheus::*;
-    let recorder = metrics_prometheus::install();
-    Ok(recorder)
-}
-
-#[cfg(feature = "prometheusd")]
-pub fn gather_metrics() -> Result<serde_json::Value, serde_json::Error> {
-    use crate::log_info;
-    use metrics_prometheus::*;
-    use prometheus::gather;
-    use prometheus::Gauge;
-    use serde_json::*;
-    let recorder = recorder_init().unwrap();
-    let report = prometheus::TextEncoder::new().encode_to_string(&recorder.registry().gather());
-    let result = serde_json::Value::String(report.unwrap());
-    log_info!("Prometheus metrics: {:?}", result);
-    Ok(result)
-}
-
-//TODO: json format
-#[cfg(feature = "prometheusd")]
-pub fn format_metrics() {
-    let report = gather_metrics().unwrap();
-    //    let type = report.get("TYPE").unwrap();
-}
-
-#[cfg(feature = "prometheusd")]
-pub fn encode_metrics() {
-    let report = gather_metrics();
-}
-
-#[cfg(feature = "dogstatd")]
-pub fn log_dogstatsd(tags: &[str], message: &str) {
-    use dogstatsd::{Client, Options, OptionsBuilder};
-    let client = Client::new(Options::default()).unwrap();
 }
 
 #[macro_export]
@@ -165,89 +132,37 @@ macro_rules! log_err {
 }
 
 #[macro_export]
-macro_rules! dogstatd_latency {
-    () => {};
-}
-#[macro_export]
-macro_rules! dogstat_info {
-    ($fmt:expr, $($arg:tt)*) => {
-        let message = format!($fmt, $($arg)*);
-        #[cfg(feature = "dogstatd")]
+macro_rules! prometheusd_latency {
+        ($fmt:expr, $($arg:tt)*) => {
+        let rpc_path = format!($fmt, $($arg)*);
+        // #[cfg(feature = "prometheusd")]
         {
-            use $crate::config::system::log_dogstatsd;
-            log_dogstatsd(6, &message);
+            use $crate::config::system::RpcMetrics;
+            use $crate::config::system::get_storage_registry;
+            let registry = get_storage_registry();
+            let metric = RpcMetrics::inst(registry).unwrap();
+            let start = std::time::Instant::now();
+            move |status: u16| {
+                let duration = start.elapsed();
+                metric.requests_complete(duration);
+            }
         }
-        println!("\x1b[35mInfo:\x1b[0m {}", message)
-    };
-    ($fmt:expr) => {
-        #[cfg(feature = "dogstatd")]
-        {
-            use $crate::config::system::log_dogstatsd;
-            log_dogstatsd(6, $fmt);
+        };
 
-        }
-        println!(concat!("\x1b[35mInfo:\x1b[0m ", $fmt))
-    };
 }
-
-#[macro_export]
-macro_rules! dogstatd_wrn {
-    ($fmt:expr, $($arg:tt)*) => {
-        let message = format!($fmt, $($arg)*);
-        #[cfg(feature = "dogstatd")]
-        {
-            use $crate::config::system::log_dogstatsd;
-            log_dogstatsd(4, &message);
-        }
-        println!("\x1b[93mWrn:\x1b[0m {}", message)
-    };
-    ($fmt:expr) => {
-        #[cfg(feature = "dogstatd")]
-        {
-            use $crate::config::system::log_dogstatsd;
-            log_dogstatsd(4, $fmt);
-        }
-        println!(concat!("\x1b[93mWrn:\x1b[0m ", $fmt))
-    };
-}
-
-#[macro_export]
-macro_rules! dogstatd_err {
-    ($fmt:expr, $($arg:tt)*) => {
-        let message = format!($fmt, $($arg)*);
-        #[cfg(feature = "dogstatd")]
-        {
-            use $crate::config::system::log_dogstatsd;
-            log_dogstatsd(3, &message);
-        }
-        println!("\x1b[31mErr:\x1b[0m {}", message)
-    };
-    ($fmt:expr) => {
-        #[cfg(feature = "dogstatd")]
-        {
-            use $crate::config::system::log_dogstatsd;
-            log_dogstatsd(3, $fmt);
-        }
-        println!(concat!("\x1b[31mErr:\x1b[0m ", $fmt))
-    };
-}
-
-#[cfg(feature = "prometheusd")]
 #[cfg(test)]
 mod tests {
-    use std::any::Any;
 
     //TODO: remove this after tests
     //sorry, im too lazy to make proper tests for this
-    use super::*;
-    use prometheus::proto::Gauge;
+
     #[tokio::test]
     async fn test_prometheus_log() {
-        let registry  = get_storage_registry();
-        let metrics = RpcMetrics::inst(registry);
-
-
-//         let expected = "prometheus_metrics";
-//         assert_eq!(report, expected);
+        // let rpc1 = Rpc::default();
+        // let registry  = get_storage_registry();
+        // let metrics = RpcMetrics::inst(registry);
+        // let expected = "prometheus_metrics";
+        // assert_eq!(report, expected);
+        unimplemented!();
     }
 }

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -15,8 +15,14 @@ use prometheus_metric_storage::{
     StorageRegistry,
 };
 use thiserror::Error;
-
+use http_body_util::Full;
+use hyper::{
+    body::Bytes,
+    Request,
+};
+use zerocopy::AsBytes;
 use std::{
+    convert::Infallible,
     collections::hash_map::HashMap,
     sync::{
         Arc,
@@ -192,12 +198,29 @@ async fn metrics_processor(
         }
     }
 }
+/// Accepts metrics request, encodes and prints
+//#[cfg(feature = "prometheusd")]
+async fn accept_metrics_request(tx: Request<hyper::body::Incoming>, metrics_rx_ws : Arc<RpcMetricsReciever>, metrics_rx_http: Arc<RpcMetricsReciever>, registry_state: Arc<RwLock<StorageRegistry>> ) -> Result<String, Infallible> 
+{
+    unimplemented!()
+    // if tx.uri().path() == "/ws_metrics"  {
+    //     todo!()
+    // } else if tx.uri().path() == "/http_metrics" {
+    //     todo!()
+    // }
+    // let mut tx
+    
 
-// async fn metrics_encoder(mut metrics_rx: RpcMetricsReciever) -> String {
-//     let encoder = prometheus::TextEncoder::new();
-//     let mut buffer = vec![];
-//     encoder.
-// }
+}
+
+async fn metrics_encoder(storage_registry: Arc<RwLock<StorageRegistry>>) -> String {
+    use prometheus::Encoder;
+    let encoder = prometheus::TextEncoder::new();
+    let mut buffer = vec![];
+    let registry = storage_registry.read().unwrap().gather();
+    encoder.encode(&registry, &mut buffer).unwrap();
+    String::from_utf8(buffer).unwrap()
+}
 
 pub async fn metrics_monitor(metrics_rx: RpcMetricsReciever, storage_registry: StorageRegistry) {
     //TODO: figure ownership mess here

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -21,6 +21,7 @@ use tokio::sync::mpsc::{
 };
 //Some goofy Rust stuff
 // #[cfg(feature = "prometheusd")]
+// #[cfg(feature = "prometheusd")]
 static METRICS_REGISTRY: Lazy<StorageRegistry> = Lazy::new(|| {
     let registry = Registry::new_custom(Some("blutgang".to_string()), None).unwrap();
     StorageRegistry::new(registry)
@@ -50,6 +51,7 @@ pub struct RpcMetrics {
     #[metric(labels("path", "method"), help = "latency of rpc calls")]
     duration: prometheus::HistogramVec,
 }
+// #[cfg(feature = "prometheusd")]
 // #[cfg(feature = "prometheusd")]
 impl RpcMetrics {
     pub fn init(registry: &StorageRegistry) -> Result<&Self, prometheus::Error> {
@@ -83,9 +85,11 @@ pub fn log_journald(level: u32, message: &str) {
 }
 
 // #[cfg(feature = "prometheusd")]
+// #[cfg(feature = "prometheusd")]
 pub fn get_storage_registry() -> &'static StorageRegistry {
     &METRICS_REGISTRY
 }
+// #[cfg(feature = "prometheusd")]
 // #[cfg(feature = "prometheusd")]
 pub fn get_registry() -> &'static Registry {
     get_storage_registry().registry()
@@ -171,8 +175,11 @@ macro_rules! prometheusd_latency {
             }
         }
         };
-
 }
+
+
+
+
 #[cfg(test)]
 mod tests {
 
@@ -188,4 +195,4 @@ mod tests {
         // assert_eq!(report, expected);
         unimplemented!();
     }
-}
+}        

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -123,29 +123,30 @@ impl RegistryChannel {
     }
     //TODO: should (Sender, Reciver) be wrapped in Result, Error?
     pub fn registry_channel() -> (MetricSender, MetricReceiver) {
-    let _ch: Lazy<RegistryChannel> = Lazy::new(|| {
-        RegistryChannel {
-            registry: Lazy::new(|| {
-                let registry =
-                    Registry::new_custom(Some("blutgang_metrics_channel".to_string()), None)
-                        .unwrap();
-                StorageRegistry::new(registry)
-            }),
-            notify: Notify::new(),
-        }
-    });
-    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    (tx, rx)
+        let _ch: Lazy<RegistryChannel> = Lazy::new(|| {
+            RegistryChannel {
+                registry: Lazy::new(|| {
+                    let registry =
+                        Registry::new_custom(Some("blutgang_metrics_channel".to_string()), None)
+                            .unwrap();
+                    StorageRegistry::new(registry)
+                }),
+                notify: Notify::new(),
+            }
+        });
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (tx, rx)
     }
 
     pub fn encode_channel(&self) -> String {
         use prometheus::Encoder;
         let encoder = prometheus::TextEncoder::new();
         let mut buffer = vec![];
-        encoder.encode(&self.registry.gather(), &mut buffer).unwrap();
+        encoder
+            .encode(&self.registry.gather(), &mut buffer)
+            .unwrap();
         String::from_utf8(buffer).unwrap()
     }
-
 }
 
 #[macro_export]

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -18,15 +18,89 @@ pub fn log_statsd(tags: &[str], message: &str) {
     unimplemented!()
 }
 
+// #[cfg(feature = "prometheusd")]
+// pub fn log_prometheus(metric: &str) {
+//     use metrics_prometheus::Recorder;
+//     use prometheus::Gauge;
+//     let _metric = prometheus::Gauge::new(format!("{metric}"), "help").unwrap();
+//     let recorder = Recorder::builder()
+//         .with_metric(_metric.clone())
+//         .build_and_install();
+// }
+
 #[cfg(feature = "prometheusd")]
-pub fn log_prometheus(metric: &str) {
-    use metrics_prometheus::Recorder;
-    use prometheus::Gauge;
-    let _metric = prometheus::Gauge::new(format!("{metric}"), "help").unwrap();
-    let recorder = Recorder::builder()
-        .with_metric(_metric.clone())
-        .build_and_install();
+pub fn gather_metrics() -> Result<String, prometheus::Error> {
+    use crate::log_info;
+    use prometheus::gather;
+    let report = prometheus::TextEncoder::new()
+        .encode_to_string(&prometheus::default_registry().gather())?
+        .trim()
+        .to_string();
+    log_info!("Prometheus metrics: {}", report);
+    Ok(report)
+    // gather::gather(&prometheus::gather(), &mut buffer).unwrap();
+    // let output = String::from_utf8(buffer).unwrap();
+    // println!("{}", output);
 }
+
+// #[cfg(feature = "prometheusd")]
+// use crate::config::error::ConfigError;
+// use prometheus::{proto::{Metric, MetricType, MetricFamily, LabelPair}, Encoder, Result};
+// use std::{collections::HashMap, io::Write};
+#[cfg(feature = "prometheusd")]
+pub fn encode_metrics() {
+    let report = gather_metrics();
+
+    // let mut buffer = vec![];
+    // encoder.encode(&metric_families, &mut buffer).unwrap();
+    // let output = String::from_utf8(buffer).unwrap();
+}
+
+// #[cfg(feature = "prometheusd")]
+// #[derive(Debug, Default)]
+// pub struct JsonEncoder;
+// #[cfg(feature = "prometheusd")]
+// impl Encoder for JsonEncoder {
+//     fn encode<W: Write>(&self, metric_families: &[MetricFamily], writer: &mut W) -> Result<()> {
+//         let mut encoded : HashMap<String, f64> = HashMap::new();
+//         for metric_family in metric_families {
+//             let name = metric_family.get_name();
+//             let metric_type = metric_family.get_field_type();
+//             for metric in metric_family.get_metric() {
+//                 match metric_type {
+//                     MetricType::COUNTER => {
+//                 encoded.entry(metric).and_modify;
+//                 metric.get_counter().get_value();
+
+//                     },
+//                     MetricType::GAUGE => {
+//                 encoded.entry(name.to_string(), metric);
+//                 metric.get_gauge().get_value();
+
+//                     },
+//                     MetricType::HISTOGRAM => {
+//                         let histogram = metric.get_histogram();
+//                         encoded.insert(name.to_string(), histogram.get_sample_sum());
+//                     },
+//                     _ => {
+//                         eprintln!("Unsupported metric type: {:?}", metric_type);
+//                     },
+//                 }
+//             }
+//         }
+//         match serde_json::to_string(&encoded) {
+//             Ok(_) => {
+//                 writer.write_all(encoded.as_bytes())?;
+//             },
+//             Err(e) => eprintln!("Failed to encode metric as JSON! Error : {}", e.to_string())
+//         }
+//         Ok(())
+//     }
+
+//     fn format_type(&self) -> &str {
+//         "json"
+//     }
+// }
 
 #[cfg(feature = "dogstatd")]
 pub fn log_dogstatsd(tags: &[str], message: &str) {

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -4,7 +4,7 @@ pub const WS_SUB_MANAGER_ID: u32 = 2;
 pub const MAGIC: u32 = 0xb153;
 
 // Version consts, dont impact functionality
-pub const VERSION_STR: &str = "Blutgang 0.3.2 Garreg Mach";
+pub const VERSION_STR: &str = "Blutgang 0.3.3 Garreg Mach";
 pub const TAGLINE: &str = "`Now there's a way forward.`";
 use atomic_refcell::AtomicRefCell;
 use crossbeam_channel::{

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -183,7 +183,9 @@ async fn metrics_processor(
     status: &u16,
     duration: Duration,
 ) {
+    let mut interval = tokio::time::interval(Duration::from_millis(10));
     loop {
+        interval.tick().await;
         while let Some(incoming) = metrics_rx.inner.recv().await {
             let _current_metrics = metrics_status.read().unwrap();
             incoming.requests_complete(path, method, status, duration);

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -7,9 +7,9 @@ pub const MAGIC: u32 = 0xb153;
 pub const VERSION_STR: &str = "Blutgang 0.3.2 Garreg Mach";
 pub const TAGLINE: &str = "`Now there's a way forward.`";
 
-use std::borrow::Borrow;
 
-use atomic_refcell::AtomicRefCell;
+
+
 use once_cell::sync::Lazy;
 use prometheus::Registry;
 use prometheus_metric_storage::StorageRegistry;
@@ -19,7 +19,6 @@ static METRICS_REGISTRY: Lazy<StorageRegistry> = Lazy::new(|| {
     let registry = Registry::new_custom(Some("blutgang".to_string()), None).unwrap();
     StorageRegistry::new(registry)
 });
-
 
 #[cfg(feature = "journald")]
 pub fn log_journald(level: u32, message: &str) {
@@ -42,41 +41,35 @@ pub fn log_statsd(tags: &[str], message: &str) {
 //         .build_and_install();
 // }
 
-
-//#[cfg(feature = "prometheusd")]
+#[cfg(feature = "prometheusd")]
 pub fn get_storage_registry() -> &'static StorageRegistry {
     &METRICS_REGISTRY
 }
 
-//#[cfg(feature = "prometheusd")]
+#[cfg(feature = "prometheusd")]
 pub fn get_registry() -> &'static Registry {
     get_storage_registry().borrow().registry()
-    
 }
 
-
 #[cfg(feature = "prometheusd")]
-pub fn recorder_init()  -> Result<metrics_prometheus::Recorder, prometheus::Error> { 
+pub fn recorder_init() -> Result<metrics_prometheus::Recorder, prometheus::Error> {
     use metrics_prometheus::*;
     let recorder = metrics_prometheus::install();
     Ok(recorder)
-         
- }
+}
 
-
-//#[cfg(feature = "prometheusd")]
+#[cfg(feature = "prometheusd")]
 pub fn gather_metrics() -> Result<serde_json::Value, serde_json::Error> {
     use crate::log_info;
     use metrics_prometheus::*;
-    use serde_json::*;
     use prometheus::gather;
     use prometheus::Gauge;
-    let recorder = recorder_init().unwrap();  
+    use serde_json::*;
+    let recorder = recorder_init().unwrap();
     //TODO: abstract this
     // recorder.register_metric(Gauge::new("dummy_gauge", "1.0").unwrap());
-    let report = prometheus::TextEncoder::new()
-        .encode_to_string(&recorder.registry().gather());
- //   let result = json!()
+    let report = prometheus::TextEncoder::new().encode_to_string(&recorder.registry().gather());
+    //   let result = json!()
     let result = serde_json::Value::String(report.unwrap());
 
     log_info!("Prometheus metrics: {:?}", result);
@@ -86,12 +79,11 @@ pub fn gather_metrics() -> Result<serde_json::Value, serde_json::Error> {
     // println!("{}", output);
 }
 
-
 //TODO: json format
-//#[cfg(feature = "prometheusd")]
+#[cfg(feature = "prometheusd")]
 pub fn format_metrics() {
     let report = gather_metrics().unwrap();
-//    let type = report.get("TYPE").unwrap();   
+    //    let type = report.get("TYPE").unwrap();
 }
 
 // #[cfg(feature = "prometheusd")]
@@ -292,18 +284,17 @@ macro_rules! dogstatd_err {
 
 #[cfg(feature = "prometheusd")]
 #[cfg(test)]
-mod tests{
-use std::any::Any;
+mod tests {
+    use std::any::Any;
 
-//TODO: remove this after tests
-//sorry, im too lazy to make proper tests for this
+    //TODO: remove this after tests
+    //sorry, im too lazy to make proper tests for this
     use super::*;
     use prometheus::proto::Gauge;
-#[tokio::test]
-async fn test_prometheus_log() {
-    let report = gather_metrics().unwrap();
-    let expected = "prometheus_metrics";
-    assert_eq!(report, expected);
+    #[tokio::test]
+    async fn test_prometheus_log() {
+        let report = gather_metrics().unwrap();
+        let expected = "prometheus_metrics";
+        assert_eq!(report, expected);
     }
-
 }

--- a/src/health/safe_block.rs
+++ b/src/health/safe_block.rs
@@ -95,9 +95,11 @@ pub async fn get_safe_block(
             let a = rpc_clone.get_finalized_block();
             let result = timeout(Duration::from_millis(ttl), a).await;
 
+            // Handle timeout as 0
             let reported_finalized = match result {
-                Ok(response) => response.unwrap(), // Handle timeout as 0
-                Err(_) => 0,                       // Handle timeout as 0
+                Ok(Ok(response)) => response,
+                Err(_) => 0,
+                Ok(Err(_)) => 0,                 
             };
 
             // Send the result to the main thread through the channel

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,8 @@ use crate::{
         cache_setup::setup_data,
         cli_args::create_match,
         system::{
-            metrics_channel,
-            metrics_monitor,
-            metrics_update_sink,
-            RpcMetrics,
+            metrics_channel, RpcMetrics, metrics_monitor, metrics_update_sink,
+                    
         },
         types::Settings,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use crate::{
             metrics_channel,
             metrics_monitor,
             RpcMetrics,
+            metrics_update_sink,
         },
         types::Settings,
     },
@@ -140,13 +141,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // We need liveness status channels even if admin is unused
     let (liveness_tx, liveness_rx) = mpsc::channel(16);
 
+    // TODO: using this for testing because of ownership eval of rx under feature flag 
+    let prometheus_enabled :bool = true;
+    let (metrics_tx, metrics_rx) = metrics_channel().await;
+    
     #[cfg(feature = "prometheusd")]
     {
+        if prometheus_enabled {
+        let metrics_rx_ws = Arc::new(&metrics_rx);
+        let metrics_rx_http = Arc::new(&metrics_rx);
         let storage_registry = prometheus_metric_storage::StorageRegistry::default();
-        let (metrics_tx, metrics_rx) = metrics_channel().await;
         let registry = RpcMetrics::init(&storage_registry);
+        let registry_arc = Arc::new(RwLock::new(registry));
         tokio::task::spawn(metrics_monitor(metrics_rx, storage_registry));
+        } else {
+            tokio::task::spawn(metrics_update_sink(metrics_rx));
+        }
+            
     }
+
+
+        
     // Spawn a thread for the admin namespace if enabled
     if admin_enabled {
         let rpc_list_admin = Arc::clone(&rpc_list_rwlock);

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -181,8 +181,6 @@ impl Rpc {
     // We don't do it within send_request because we might kill it if it times out.
     pub fn update_latency(&mut self, latest: f64) {
         // #[cfg(feature = "prometheusd")]
-        // let metric_channel = RegistryChannel::new();
-        // #[cfg(feature = "prometheusd")]
         // let metric =
         //     RpcMetrics::init(RegistryChannel::get_storage_registry(&metric_channel)).unwrap();
         // #[cfg(feature = "prometheusd")]

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -1,9 +1,9 @@
 use crate::config::system::{
+    push_latency,
     MetricReceiver,
     MetricSender,
     RegistryChannel,
     RpcMetrics,
-    push_latency,
 };
 use crate::log_info;
 use crate::rpc::error::RpcError;
@@ -188,15 +188,13 @@ impl Rpc {
     // Update the latency of the last n calls.
     // We don't do it within send_request because we might kill it if it times out.
     pub fn update_latency(&mut self, latest: f64) {
-        // #[cfg(feature = "prometheusd")]
-        // let metric = RpcMetrics::init(get_storage_registry()).unwrap();
         #[cfg(feature = "prometheusd")]
         let metric_channel = RegistryChannel::new();
         #[cfg(feature = "prometheusd")]
         let metric =
             RpcMetrics::init(RegistryChannel::get_storage_registry(&metric_channel)).unwrap();
         #[cfg(feature = "prometheusd")]
-        let (mut tx, mut rx) = RegistryChannel::channel("prometheus latency demo");
+        let (mut tx, mut rx) = RegistryChannel::channel("Rpc latency ");
         // If we have data >= to ma_length, remove the first one in line
         if self.status.latency_data.len() >= self.status.ma_length as usize {
             self.status.latency_data.remove(0);

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -54,7 +54,6 @@ pub struct Rpc {
 // For example, if we have a URL: https://eth-mainnet.g.alchemy.com/v2/api-key
 // as input, we output: https://eth-mainnet.g.alchemy.com/
 fn sanitize_url(url: &str) -> Result<String, url::ParseError> {
-    let _parsed_url = Url::parse(url)?;
     let parsed_url = Url::parse(url)?;
 
     // Build a new URL with the scheme, host, and port (if any), but without the path or query

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -1,5 +1,4 @@
 use crate::config::system::{
-    push_latency,
     MetricReceiver,
     MetricSender,
     RegistryChannel,
@@ -206,12 +205,7 @@ impl Rpc {
             self.status.latency_data.iter().sum::<f64>() / self.status.latency_data.len() as f64;
         self.status.latency = avg;
         #[cfg(feature = "prometheusd")]
-        push_latency(metric.clone(), &self.url, &self.name, avg, rx, tx);
-
-        // RegistryChannel::push_latency(metric.clone(), &self.url, &self.name, avg, rx, tx);
-        // Non-channel version
-        // #[cfg(feature = "prometheusd")]
-        // RpcMetrics::push_latency(&metric, &self.url, &self.name, avg);
+        RegistryChannel::on_push_latency(&metric_channel, &self.name, &self.url, avg, metric.clone(), rx, tx);
         #[cfg(feature = "prometheusd")]
         let report = RegistryChannel::encode_channel(&metric_channel);
         #[cfg(feature = "prometheusd")]

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -209,7 +209,7 @@ impl Rpc {
         #[cfg(feature = "prometheusd")]
         let report = RegistryChannel::encode_channel(&metric_channel);
         #[cfg(feature = "prometheusd")]
-        log_info!("Prometheus metrics: {}", report);
+        log_info!("Prometheus metrics: {}", report.unwrap());
     }
 }
 

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -3,6 +3,7 @@ use crate::config::system::{
     MetricSender,
     RegistryChannel,
     RpcMetrics,
+    push_latency,
 };
 use crate::log_info;
 use crate::rpc::error::RpcError;
@@ -207,7 +208,9 @@ impl Rpc {
             self.status.latency_data.iter().sum::<f64>() / self.status.latency_data.len() as f64;
         self.status.latency = avg;
         #[cfg(feature = "prometheusd")]
-        RegistryChannel::push_latency(metric.clone(), &self.url, &self.name, avg, rx, tx);
+        push_latency(metric.clone(), &self.url, &self.name, avg, rx, tx);
+
+        // RegistryChannel::push_latency(metric.clone(), &self.url, &self.name, avg, rx, tx);
         // Non-channel version
         // #[cfg(feature = "prometheusd")]
         // RpcMetrics::push_latency(&metric, &self.url, &self.name, avg);

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -3,7 +3,7 @@ use crate::{
     rpc::error::RpcError,
 };
 use crate::log_info;
-use crate::config::system::{encode, get_registry, get_storage_registry,  registry_channel, RpcMetrics};
+use crate::config::system::{encode, get_registry, get_storage_registry,  RegistryChannel, RpcMetrics};
 use reqwest::Client;
 use serde_json::{
     json,

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -208,14 +208,14 @@ impl Rpc {
             self.status.latency_data.iter().sum::<f64>() / self.status.latency_data.len() as f64;
         self.status.latency = avg;
         #[cfg(feature = "prometheusd")]
-        RegistryChannel::push_metrics(metric.clone(), &self.url, &self.name, avg, rx, tx, );
+        RegistryChannel::push_metrics(metric.clone(), &self.url, &self.name, avg, rx, tx);
         // Non-channel version
         // #[cfg(feature = "prometheusd")]
         // RpcMetrics::push_latency(&metric, &self.url, &self.name, avg);
         #[cfg(feature = "prometheusd")]
         let report = RegistryChannel::encode_channel(&metric_channel);
         #[cfg(feature = "prometheusd")]
-        log_info!("Prometheus metrics: {}", report);            
+        log_info!("Prometheus metrics: {}", report);
     }
 }
 

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -1,12 +1,16 @@
 
-use crate::rpc::error::RpcError;
+use crate::{
+    rpc::error::RpcError,
+};
+use crate::log_info;
+use crate::config::system::{encode, get_registry, get_storage_registry,  registry_channel, RpcMetrics};
 use reqwest::Client;
-use url::Url;
 use serde_json::{
     json,
     Value,
 };
-
+use url::Url;
+ 
 // All as floats so we have an easier time getting averages, stats and terminology copied from flood.
 #[derive(Debug, Clone, Default)]
 pub struct Status {
@@ -45,7 +49,7 @@ pub struct Rpc {
 // For example, if we have a URL: https://eth-mainnet.g.alchemy.com/v2/api-key
 // as input, we output: https://eth-mainnet.g.alchemy.com/
 fn sanitize_url(url: &str) -> Result<String, url::ParseError> {
-    let parsed_url = Url::parse(url)?;
+    let _parsed_url = Url::parse(url)?;
     let parsed_url = Url::parse(url)?;
 
     // Build a new URL with the scheme, host, and port (if any), but without the path or query
@@ -206,10 +210,11 @@ impl Rpc {
         let avg =
             self.status.latency_data.iter().sum::<f64>() / self.status.latency_data.len() as f64;
         self.status.latency = avg;
+        //TODO: try this with channel
         #[cfg(feature = "prometheusd")]
         RpcMetrics::push_latency(&metric, &self.url, &self.name, avg);
         #[cfg(feature = "prometheusd")]
-        println!("prometheus metrics latency {}", encode(get_registry()));
+        log_info!("prometheus metrics latency {}", encode(get_registry()));
     }
 }
 

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -2,7 +2,6 @@
 use crate::rpc::error::RpcError;
 use reqwest::Client;
 use url::Url;
-use crate::config::system::{RpcMetrics, get_storage_registry, encode, get_registry};
 use serde_json::{
     json,
     Value,
@@ -46,6 +45,7 @@ pub struct Rpc {
 // For example, if we have a URL: https://eth-mainnet.g.alchemy.com/v2/api-key
 // as input, we output: https://eth-mainnet.g.alchemy.com/
 fn sanitize_url(url: &str) -> Result<String, url::ParseError> {
+    let parsed_url = Url::parse(url)?;
     let parsed_url = Url::parse(url)?;
 
     // Build a new URL with the scheme, host, and port (if any), but without the path or query

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -208,7 +208,7 @@ impl Rpc {
             self.status.latency_data.iter().sum::<f64>() / self.status.latency_data.len() as f64;
         self.status.latency = avg;
         #[cfg(feature = "prometheusd")]
-        RegistryChannel::push_metrics(metric.clone(), &self.url, &self.name, avg, rx, tx);
+        RegistryChannel::push_latency(metric.clone(), &self.url, &self.name, avg, rx, tx);
         // Non-channel version
         // #[cfg(feature = "prometheusd")]
         // RpcMetrics::push_latency(&metric, &self.url, &self.name, avg);

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -192,8 +192,8 @@ impl Rpc {
         #[cfg(feature = "prometheusd")]
         let metric_channel = RegistryChannel::new();
         #[cfg(feature = "prometheusd")]
-        let metric = RpcMetrics::init(RegistryChannel::get_storage_registry(&metric_channel))
-            .unwrap();
+        let metric =
+            RpcMetrics::init(RegistryChannel::get_storage_registry(&metric_channel)).unwrap();
         #[cfg(feature = "prometheusd")]
         let (mut tx, mut rx) = RegistryChannel::channel("prometheus latency demo");
         // If we have data >= to ma_length, remove the first one in line

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -1,11 +1,9 @@
 use crate::rpc::error::RpcError;
+use crate::config::system::{encode, get_registry, get_storage_registry, RpcMetrics};
 use reqwest::Client;
 use url::Url;
 
-use serde_json::{
-    json,
-    Value,
-};
+use serde_json::{json, Value};
 
 // All as floats so we have an easier time getting averages, stats and terminology copied from flood.
 #[derive(Debug, Clone, Default)]
@@ -45,7 +43,7 @@ pub struct Rpc {
 // For example, if we have a URL: https://eth-mainnet.g.alchemy.com/v2/api-key
 // as input, we output: https://eth-mainnet.g.alchemy.com/
 fn sanitize_url(url: &str) -> Result<String, url::ParseError> {
-    let parsed_url = Url::parse(&url)?;
+    let parsed_url = Url::parse(url)?;
 
     // Build a new URL with the scheme, host, and port (if any), but without the path or query
     let sanitized = Url::parse(&format!(
@@ -112,9 +110,11 @@ impl Rpc {
 
     // Generic fn to send rpc
     pub async fn send_request(&self, tx: Value) -> Result<String, crate::rpc::types::RpcError> {
+        let _path = self.url.clone();
+        let _method = tx["method"].as_str().unwrap_or("unknown");
+        let _start = std::time::Instant::now();
         #[cfg(feature = "debug-verbose")]
         println!("Sending request: {}", tx.clone());
-
         let response = match self.client.post(&self.url).json(&tx).send().await {
             Ok(response) => response,
             Err(err) => {
@@ -123,7 +123,15 @@ impl Rpc {
                 ))
             }
         };
-
+        #[cfg(feature = "prometheusd")]
+        {
+            let metric = RpcMetrics::inst(get_storage_registry()).unwrap();
+            let status = response.status().as_u16();
+            //RpcMetrics::requests_complete(&metric, &path, &method, &status, );
+            let a = response.text().await.unwrap();
+            //println!("prometheusd: {:?}", metric.clone());
+            return Ok(a);
+        }
         #[cfg(feature = "debug-verbose")]
         {
             let a = response.text().await.unwrap();
@@ -183,6 +191,8 @@ impl Rpc {
     // Update the latency of the last n calls.
     // We don't do it within send_request because we might kill it if it times out.
     pub fn update_latency(&mut self, latest: f64) {
+        #[cfg(feature = "prometheusd")]
+        let metric = RpcMetrics::inst(get_storage_registry()).unwrap();
         // If we have data >= to ma_length, remove the first one in line
         if self.status.latency_data.len() >= self.status.ma_length as usize {
             self.status.latency_data.remove(0);
@@ -190,8 +200,13 @@ impl Rpc {
 
         // Update latency
         self.status.latency_data.push(latest);
-        self.status.latency =
+        let avg =
             self.status.latency_data.iter().sum::<f64>() / self.status.latency_data.len() as f64;
+        self.status.latency = avg;
+        #[cfg(feature = "prometheusd")]
+        RpcMetrics::push_latency(&metric, &self.url, &self.name, avg);
+        #[cfg(feature = "prometheusd")]
+        println!("prometheus metrics latency {}", encode(get_registry()));
     }
 }
 

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -1,10 +1,3 @@
-use crate::config::system::{
-    MetricReceiver,
-    MetricSender,
-    RegistryChannel,
-    RpcMetrics,
-};
-use crate::log_info;
 use crate::rpc::error::RpcError;
 use reqwest::Client;
 use serde_json::{

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -187,13 +187,13 @@ impl Rpc {
     // Update the latency of the last n calls.
     // We don't do it within send_request because we might kill it if it times out.
     pub fn update_latency(&mut self, latest: f64) {
-        #[cfg(feature = "prometheusd")]
-        let metric_channel = RegistryChannel::new();
-        #[cfg(feature = "prometheusd")]
-        let metric =
-            RpcMetrics::init(RegistryChannel::get_storage_registry(&metric_channel)).unwrap();
-        #[cfg(feature = "prometheusd")]
-        let (mut tx, mut rx) = RegistryChannel::channel("Rpc latency ");
+        // #[cfg(feature = "prometheusd")]
+        // let metric_channel = RegistryChannel::new();
+        // #[cfg(feature = "prometheusd")]
+        // let metric =
+        //     RpcMetrics::init(RegistryChannel::get_storage_registry(&metric_channel)).unwrap();
+        // #[cfg(feature = "prometheusd")]
+        // let (mut tx, mut rx) = RegistryChannel::channel("Rpc latency ");
         // If we have data >= to ma_length, remove the first one in line
         if self.status.latency_data.len() >= self.status.ma_length as usize {
             self.status.latency_data.remove(0);
@@ -204,12 +204,12 @@ impl Rpc {
         let avg =
             self.status.latency_data.iter().sum::<f64>() / self.status.latency_data.len() as f64;
         self.status.latency = avg;
-        #[cfg(feature = "prometheusd")]
-        RegistryChannel::on_push_latency(&metric_channel, &self.name, &self.url, avg, metric.clone(), rx, tx);
-        #[cfg(feature = "prometheusd")]
-        let report = RegistryChannel::encode_channel(&metric_channel);
-        #[cfg(feature = "prometheusd")]
-        log_info!("Prometheus metrics: {}", report.unwrap());
+        // #[cfg(feature = "prometheusd")]
+        // RegistryChannel::on_push_latency(&metric_channel, &self.name, &self.url, avg, metric.clone(), rx, tx);
+        // #[cfg(feature = "prometheusd")]
+        // let report = RegistryChannel::encode_channel(&metric_channel);
+        // #[cfg(feature = "prometheusd")]
+        // log_info!("Prometheus metrics: {}", report.unwrap());
     }
 }
 

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -1,4 +1,12 @@
-use crate::config::system::{encode, get_registry, get_storage_registry, RpcMetrics, RegistryChannel};
+use crate::config::system::{
+    encode,
+    get_registry,
+    get_storage_registry,
+    MetricReceiver,
+    MetricSender,
+    RegistryChannel,
+    RpcMetrics,
+};
 use crate::log_info;
 use crate::rpc::error::RpcError;
 use reqwest::Client;
@@ -196,6 +204,10 @@ impl Rpc {
             self.status.latency_data.iter().sum::<f64>() / self.status.latency_data.len() as f64;
         self.status.latency = avg;
         //TODO: try this with channel
+        // #[cfg(feature = "prometheusd")]
+        // let (mut rx, mut tx) = RegistryChannel::registry_channel();
+        // #[cfg(feature = "prometheusd")]
+        // RegistryChannel::push_metrics(rx, tx);
         #[cfg(feature = "prometheusd")]
         RpcMetrics::push_latency(&metric, &self.url, &self.name, avg);
         #[cfg(feature = "prometheusd")]

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -1,9 +1,12 @@
+
 use crate::rpc::error::RpcError;
-use crate::config::system::{encode, get_registry, get_storage_registry, RpcMetrics};
 use reqwest::Client;
 use url::Url;
-
-use serde_json::{json, Value};
+use crate::config::system::{RpcMetrics, get_storage_registry, encode, get_registry};
+use serde_json::{
+    json,
+    Value,
+};
 
 // All as floats so we have an easier time getting averages, stats and terminology copied from flood.
 #[derive(Debug, Clone, Default)]
@@ -125,7 +128,7 @@ impl Rpc {
         };
         #[cfg(feature = "prometheusd")]
         {
-            let metric = RpcMetrics::inst(get_storage_registry()).unwrap();
+            let metric = RpcMetrics::init(get_storage_registry()).unwrap();
             let status = response.status().as_u16();
             //RpcMetrics::requests_complete(&metric, &path, &method, &status, );
             let a = response.text().await.unwrap();
@@ -192,7 +195,7 @@ impl Rpc {
     // We don't do it within send_request because we might kill it if it times out.
     pub fn update_latency(&mut self, latest: f64) {
         #[cfg(feature = "prometheusd")]
-        let metric = RpcMetrics::inst(get_storage_registry()).unwrap();
+        let metric = RpcMetrics::init(get_storage_registry()).unwrap();
         // If we have data >= to ma_length, remove the first one in line
         if self.status.latency_data.len() >= self.status.ma_length as usize {
             self.status.latency_data.remove(0);

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -1,7 +1,4 @@
 use crate::config::system::{
-    encode,
-    get_registry,
-    get_storage_registry,
     MetricReceiver,
     MetricSender,
     RegistryChannel,
@@ -190,10 +187,13 @@ impl Rpc {
     // Update the latency of the last n calls.
     // We don't do it within send_request because we might kill it if it times out.
     pub fn update_latency(&mut self, latest: f64) {
-        #[cfg(feature = "prometheusd")]
-        let metric = RpcMetrics::init(get_storage_registry()).unwrap();
+        // #[cfg(feature = "prometheusd")]
+        // let metric = RpcMetrics::init(get_storage_registry()).unwrap();
         #[cfg(feature = "prometheusd")]
         let metric_channel = RegistryChannel::new();
+        #[cfg(feature = "prometheusd")]
+        let metric = RpcMetrics::init(RegistryChannel::get_storage_registry(&metric_channel))
+            .unwrap();
         #[cfg(feature = "prometheusd")]
         let (mut tx, mut rx) = RegistryChannel::channel("prometheus latency demo");
         // If we have data >= to ma_length, remove the first one in line

--- a/src/websocket/client.rs
+++ b/src/websocket/client.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     log_err,
     log_info,
-    log_wrn,
     rpc::types::Rpc,
     websocket::{
         error::WsError,
@@ -197,8 +196,10 @@ pub async fn ws_conn(
 
                     let rax = match unsafe { from_str(&mut ws_message) } {
                         Ok(rax) => rax,
-                        Err(e) => {
-                            log_wrn!("Couldn't deserialize ws_conn response: {}", e);
+                        Err(_e) => {
+                            #[cfg(feature = "debug-verbose")]
+                            log_wrn!("Couldn't deserialize ws_conn response: {}", _e);
+
                             continue;
                         }
                     };

--- a/src/websocket/client.rs
+++ b/src/websocket/client.rs
@@ -144,7 +144,7 @@ pub async fn create_ws_vec(
 
     ws_handles
 }
-
+//TODO: figure if metric is registered
 pub async fn ws_conn(
     rpc: Rpc,
     rpc_list: Arc<RwLock<Vec<Rpc>>>,

--- a/src/websocket/server.rs
+++ b/src/websocket/server.rs
@@ -50,12 +50,12 @@ pub async fn serve_websocket(
     let (mut websocket_sink, mut websocket_stream) = websocket.split();
 
     // Create channels for message send/receiving
-    #[cfg(feature = "prometheusd")]
-    let metric_channel = RegistryChannel::new();
-    #[cfg(feature = "prometheusd")]
-    let metric = RpcMetrics::init(RegistryChannel::get_storage_registry(&metric_channel)).unwrap();
-    #[cfg(feature = "prometheusd")]
-    let (metric_tx, mut metric_rx) = RegistryChannel::channel("ws server");
+    // #[cfg(feature = "prometheusd")]
+    // let metric_channel = RegistryChannel::new();
+    // #[cfg(feature = "prometheusd")]
+    // let metric = RpcMetrics::init(RegistryChannel::get_storage_registry(&metric_channel)).unwrap();
+    // #[cfg(feature = "prometheusd")]
+    // let (metric_tx, mut metric_rx) = RegistryChannel::channel("ws server");
     let (tx, mut rx) = mpsc::unbounded_channel::<RequestResult>();
 
     // Generate an id for our user
@@ -65,8 +65,8 @@ pub async fn serve_websocket(
 
     // Add the user to the sink map
     log_info!("Adding user {} to sink map", user_id);
-    #[cfg(feature = "prometheusd")]
-    log_info!("Prometheus metrics on {}", metric_tx.name);
+    // #[cfg(feature = "prometheusd")]
+    // log_info!("Prometheus metrics on {}", metric_tx.name);
 
     let user_data = tx.clone();
     sub_data.add_user(user_id, user_data);


### PR DESCRIPTION
Addresses #62 with the feature `prometheusd`
Currently WIP , exposes a Prometheus registry, metrics with labels and associated  functions

### Detailed

-  `METRICS_REGISTRY` is a static Prometheus registry that is fetched
- `RpcMetrics` is a subsystem to record requests, latency. Associated functions fetch METRICS_REGISTRY instance and records a request and it's duration, as well as push duration directly
- function to encode to string for debug 
- example of pushing latency to RpcMetrics bucket



