### PR TITLE
Blutgang 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,15 +19,21 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
  "zerocopy",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -46,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -139,15 +145,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blake3"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -175,7 +181,7 @@ dependencies = [
  "futures",
  "futures-util",
  "http-body-util",
- "hyper 1.1.0",
+ "hyper 1.2.0",
  "hyper-tungstenite",
  "hyper-util-blutgang",
  "jemallocator",
@@ -207,9 +213,9 @@ checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byteorder"
@@ -225,9 +231,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
  "jobserver",
  "libc",
@@ -241,32 +247,32 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.0"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.0"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -319,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -622,16 +628,16 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -641,16 +647,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
+checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
 dependencies = [
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -660,40 +666,35 @@ dependencies = [
 
 [[package]]
 name = "halfbrown"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5681137554ddff44396e5f149892c769d45301dd9aa19c51602a89ee214cb0ec"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown",
  "serde",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "e57fa0ae458eb99874f54c09f4f9174f8b45fb87e854536a4e608696247f0c23"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-
-[[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -702,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -718,7 +719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -729,18 +730,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http 1.0.0",
+ "http 1.1.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.0.0",
+ "futures-core",
+ "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
 ]
@@ -767,8 +768,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
- "http 0.2.11",
+ "h2 0.3.25",
+ "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
@@ -783,20 +784,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.2",
- "http 1.0.0",
+ "h2 0.4.3",
+ "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "smallvec",
  "tokio",
  "want",
 ]
@@ -821,7 +823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "096e0568151fedc7a77619c28f56a86b1cbae56aed4dfe443efbd739229c2733"
 dependencies = [
  "http-body-util",
- "hyper 1.1.0",
+ "hyper 1.2.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -837,9 +839,9 @@ checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.1.0",
+ "hyper 1.2.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -854,9 +856,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.0.0",
+ "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.1.0",
+ "hyper 1.2.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -900,12 +902,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -960,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1087,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
@@ -1114,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -1203,11 +1205,11 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.63"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -1235,9 +1237,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -1288,18 +1290,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1320,9 +1322,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "powerfmt"
@@ -1338,9 +1340,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1395,17 +1397,17 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
- "http 0.2.11",
+ "h2 0.3.25",
+ "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-tls",
@@ -1435,16 +1437,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1459,7 +1462,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1477,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "schannel"
@@ -1521,18 +1524,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1541,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -1649,12 +1652,12 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1677,9 +1680,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1730,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1742,18 +1745,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1846,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1981,7 +1984,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.11",
+ "http 0.2.12",
  "httparse",
  "log",
  "native-tls",
@@ -2012,9 +2015,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -2095,9 +2098,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2105,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -2120,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2132,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2142,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2155,15 +2158,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2197,7 +2200,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2215,7 +2218,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2235,17 +2238,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -2256,9 +2259,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2268,9 +2271,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2280,9 +2283,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2292,9 +2295,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2304,9 +2307,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2316,9 +2319,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2328,15 +2331,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
@@ -2353,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
+checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "blutgang"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "blutgang"
-version = "0.3.3"
+version = "0.3.3-rc1"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blutgang"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["makemake <vukasin@gostovic.me>, Rainshower Labs, contributors"]
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blutgang"
-version = "0.3.3"
+version = "0.3.3-rc1"
 edition = "2021"
 authors = ["makemake <vukasin@gostovic.me>, Rainshower Labs, contributors"]
 license-file = "LICENSE"

--- a/example_config.toml
+++ b/example_config.toml
@@ -12,7 +12,8 @@ ma_length = 100
 sort_on_startup = true
 # Enable health checking
 health_check = true
-# Enable content type header checking
+# Enable content type header checking. Set this to `true` if you want
+# Blutgang to be JSON-RPC compliant.
 header_check = true
 # Acceptable time to wait for a response in ms
 ttl = 30
@@ -57,7 +58,7 @@ compression = false
 # Print DB profile when dropped. Doesn't do anything for now.
 print_profile = false
 # Frequency of flushes in ms
-flush_every_ms = 24000
+flush_every_ms = 240
 
 # Add separate RPCs as TOML tables
 # DO NOT name an rpc `blutgang`, `admin`, or `sled`

--- a/example_config.toml
+++ b/example_config.toml
@@ -12,6 +12,8 @@ ma_length = 100
 sort_on_startup = true
 # Enable health checking
 health_check = true
+# Enable content type header checking
+header_check = true
 # Acceptable time to wait for a response in ms
 ttl = 30
 # How many times to retry a request before giving up

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
             systemd
             clang
             gdb
+            python311Packages.requests
             (rust-bin.stable.latest.default.override {
               extensions = [ "rust-src" "rustfmt-preview" "rust-analyzer" ];
             })

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,9 @@
         pkgs = import nixpkgs {
           inherit system overlays;
         };
-      cargoMeta = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-      in {
+        cargoMeta = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      in
+      {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = cargoMeta.package.name;
           version = cargoMeta.package.version;
@@ -33,7 +34,6 @@
               extensions = [ "rust-src" "rustfmt-preview" "rust-analyzer" ];
             })
           ];
-
           cargoBuildFlags = [ "--profile maxperf" ];
         };
 
@@ -43,8 +43,10 @@
             pkg-config
             openssl
             systemd
-            (rust-bin.stable.latest.default.override { 
-              extensions = [ "rust-src" "rustfmt-preview" "rust-analyzer"];
+            clang
+            gdb
+            (rust-bin.stable.latest.default.override {
+              extensions = [ "rust-src" "rustfmt-preview" "rust-analyzer" ];
             })
           ];
 
@@ -53,9 +55,13 @@
             export RUSTC_WRAPPER=$(which sccache)
             export OLD_PS1="$PS1" # Preserve the original PS1
             export PS1="nix-shell:blutgang $PS1" # Customize this line as needed
+
+            # Set NIX_LD and NIX_LD_LIBRARY_PATH for rust-analyzer
+            export NIX_LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [ pkgs.glibc pkgs.gcc-unwrapped.lib ]}"
+            export NIX_LD="${pkgs.stdenv.cc}/nix-support/dynamic-linker"
           '';
 
-          # reser PS1
+          # reset ps1
           shellExitHook = ''
             export PS1="$OLD_PS1"
           '';

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,6 @@ pkgs.mkShell {
     pkgs.pkg-config
     pkgs.openssl
     pkgs.systemdLibs
-    pkgs.cargo2nix
   ];
 
   shellHook = ''

--- a/src/admin/liveready.rs
+++ b/src/admin/liveready.rs
@@ -1,0 +1,478 @@
+use std::{
+    convert::Infallible,
+    sync::{
+        Arc,
+        RwLock,
+    },
+};
+
+use http_body_util::Full;
+
+use tokio::sync::{
+    mpsc,
+    oneshot,
+};
+
+use hyper::body::Bytes;
+
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
+pub enum ReadinessState {
+    Ready,
+    #[default]
+    Setup,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
+pub enum HealthState {
+    #[default]
+    Healthy, // Everything nominal
+    MissingRpcs, // Some RPCs are not following the head but otherwise ok
+    Unhealthy,   // Nothing works
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
+pub struct LiveReady {
+    readiness: ReadinessState,
+    health: HealthState,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum LiveReadyUpdate {
+    Readiness(ReadinessState),
+    Health(HealthState),
+}
+
+// These 2 are used to send and receive updates related to the current
+// health of blutgang.
+pub type LiveReadyUpdateRecv = mpsc::Receiver<LiveReadyUpdate>;
+pub type LiveReadyUpdateSnd = mpsc::Sender<LiveReadyUpdate>;
+
+// These are used to request/return updates about health
+// pub type LiveReadyRecv = oneshot::Receiver<LiveReady>;
+pub type LiveReadySnd = oneshot::Sender<LiveReady>;
+
+pub type LiveReadyRequestRecv = mpsc::Receiver<LiveReadySnd>;
+pub type LiveReadyRequestSnd = mpsc::Sender<LiveReadySnd>;
+
+// Macros to make returning statuses less ugly in code
+macro_rules! ok {
+    () => {
+        Ok(hyper::Response::builder()
+            .status(200)
+            .body(Full::new(Bytes::from("OK")))
+            .unwrap())
+    };
+}
+
+macro_rules! partial_ok {
+    () => {
+        Ok(hyper::Response::builder()
+            .status(202)
+            .body(Full::new(Bytes::from("RPC")))
+            .unwrap())
+    };
+}
+
+macro_rules! nok {
+    () => {
+        Ok(hyper::Response::builder()
+            .status(503)
+            .body(Full::new(Bytes::from("NOK")))
+            .unwrap())
+    };
+}
+
+// Listen for liveness update messages and update the current status accordingly
+async fn liveness_listener(
+    mut liveness_receiver: LiveReadyUpdateRecv,
+    liveness_status: Arc<RwLock<LiveReady>>,
+) {
+    while let Some(update) = liveness_receiver.recv().await {
+        match update {
+            LiveReadyUpdate::Readiness(state) => {
+                let mut liveness = liveness_status.write().unwrap();
+                liveness.readiness = state;
+            }
+            LiveReadyUpdate::Health(state) => {
+                let mut liveness = liveness_status.write().unwrap();
+                liveness.health = state;
+            }
+        }
+    }
+}
+
+// Receives requests about current status updates and returns the current liveness
+async fn liveness_request_processor(
+    mut liveness_request_receiver: LiveReadyRequestRecv,
+    liveness_status: Arc<RwLock<LiveReady>>,
+) {
+    loop {
+        while let Some(incoming) = liveness_request_receiver.recv().await {
+            let current_status = *liveness_status.read().unwrap();
+            let _ = incoming.send(current_status);
+        }
+    }
+}
+
+// Monitor for new liveness updates and update the statuses accordingly.
+//
+// Also handles incoming requests about the current status.
+pub(in crate::r#admin) async fn liveness_monitor(
+    liveness_receiver: LiveReadyUpdateRecv,
+    liveness_request_receiver: LiveReadyRequestRecv,
+) {
+    let liveness_status = Arc::new(RwLock::new(LiveReady::default()));
+
+    // Spawn thread for listening and updating the current liveness status
+    let liveness_status_listener = liveness_status.clone();
+    tokio::spawn(liveness_listener(
+        liveness_receiver,
+        liveness_status_listener,
+    ));
+
+    // Listens to incoming requests about the current liveness
+    liveness_request_processor(liveness_request_receiver, liveness_status).await;
+}
+
+pub async fn accept_readiness_request(
+    liveness_request_sender: LiveReadyRequestSnd,
+) -> Result<hyper::Response<Full<Bytes>>, Infallible> {
+    let (tx, rx) = oneshot::channel();
+
+    let _ = liveness_request_sender.send(tx).await;
+
+    let rax = match rx.await {
+        Ok(v) => v,
+        Err(_) => {
+            return nok!();
+        }
+    };
+
+    if rax.readiness == ReadinessState::Ready {
+        return ok!();
+    }
+
+    nok!()
+}
+
+pub async fn accept_health_request(
+    liveness_request_sender: LiveReadyRequestSnd,
+) -> Result<hyper::Response<Full<Bytes>>, Infallible> {
+    let (tx, rx) = oneshot::channel();
+
+    let _ = liveness_request_sender.send(tx).await;
+
+    let rax = match rx.await {
+        Ok(v) => v,
+        Err(_) => {
+            return nok!();
+        }
+    };
+
+    match rax.health {
+        HealthState::Healthy => ok!(),
+        HealthState::MissingRpcs => partial_ok!(),
+        HealthState::Unhealthy => nok!(),
+    }
+}
+
+// Just a sink used to immediately discard request in cases where admin is disabled
+pub async fn liveness_update_sink(mut liveness_rx: LiveReadyUpdateRecv) {
+    loop {
+        while (liveness_rx.recv().await).is_some() {
+            continue;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Rpc;
+    use tokio::sync::{
+        mpsc,
+        oneshot,
+    };
+    use tokio::time::sleep;
+    use tokio::time::Duration;
+
+    #[tokio::test]
+    async fn test_liveness_listener_updates_status() {
+        let (update_snd, update_recv) = mpsc::channel(10);
+        let liveness_status = Arc::new(RwLock::new(LiveReady::default()));
+
+        // Simulate sending updates
+        let liveness_status_clone = liveness_status.clone();
+        tokio::spawn(async move {
+            liveness_listener(update_recv, liveness_status_clone).await;
+        });
+
+        update_snd
+            .send(LiveReadyUpdate::Readiness(ReadinessState::Ready))
+            .await
+            .unwrap();
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::MissingRpcs))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await; // Give time for async updates
+
+        assert_eq!(
+            liveness_status.read().unwrap().readiness,
+            ReadinessState::Ready
+        );
+        assert_eq!(
+            liveness_status.read().unwrap().health,
+            HealthState::MissingRpcs
+        );
+    }
+
+    #[tokio::test]
+    async fn test_accept_readiness_request_returns_correct_response() {
+        let (request_snd, request_recv) = mpsc::channel(1);
+        let liveness_status = Arc::new(RwLock::new(LiveReady {
+            readiness: ReadinessState::Ready,
+            health: HealthState::Healthy,
+        }));
+
+        tokio::spawn(liveness_request_processor(
+            request_recv,
+            liveness_status.clone(),
+        ));
+
+        let response = accept_readiness_request(request_snd.clone()).await.unwrap();
+        assert_eq!(response.status(), 200);
+
+        // Testing with readiness set to Setup
+        let (tx, _rx) = oneshot::channel();
+        request_snd.send(tx).await.unwrap();
+        liveness_status.write().unwrap().readiness = ReadinessState::Setup;
+        let response = accept_readiness_request(request_snd).await.unwrap();
+        assert_eq!(response.status(), 503);
+    }
+
+    #[tokio::test]
+    async fn test_accept_health_request_returns_correct_response() {
+        let (request_snd, request_recv) = mpsc::channel(1);
+        let liveness_status = Arc::new(RwLock::new(LiveReady {
+            readiness: ReadinessState::Ready,
+            health: HealthState::Healthy,
+        }));
+
+        tokio::spawn(liveness_request_processor(
+            request_recv,
+            liveness_status.clone(),
+        ));
+
+        // Test with healthy state
+        let response = accept_health_request(request_snd.clone()).await.unwrap();
+        assert_eq!(response.status(), 200);
+
+        // Test with MissingRpcs state
+        let (tx, _rx) = oneshot::channel();
+        request_snd.send(tx).await.unwrap();
+        liveness_status.write().unwrap().health = HealthState::MissingRpcs;
+        let response = accept_health_request(request_snd.clone()).await.unwrap();
+        assert_eq!(response.status(), 202);
+
+        // Test with Unhealthy state
+        let (tx, _rx) = oneshot::channel();
+        request_snd.send(tx).await.unwrap();
+        liveness_status.write().unwrap().health = HealthState::Unhealthy;
+        let response = accept_health_request(request_snd).await.unwrap();
+        assert_eq!(response.status(), 503);
+    }
+
+    #[tokio::test]
+    async fn test_liveness_update_sink_discards_updates() {
+        let (update_snd, update_recv) = mpsc::channel(10);
+
+        // Simulate a sink that discards updates
+        tokio::spawn(async move {
+            liveness_update_sink(update_recv).await;
+        });
+
+        update_snd
+            .send(LiveReadyUpdate::Readiness(ReadinessState::Ready))
+            .await
+            .unwrap();
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::MissingRpcs))
+            .await
+            .unwrap();
+
+        // No assertion here as we're testing the sink's ability to simply discard incoming messages
+        assert!(
+            true,
+            "Successfully discarded updates without affecting the test flow"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_and_request_liveness_status_concurrently() {
+        let (update_snd, update_recv) = mpsc::channel(10);
+        let (request_snd, request_recv) = mpsc::channel(10);
+        let liveness_status = Arc::new(RwLock::new(LiveReady::default()));
+        let liveness_status_clone = liveness_status.clone();
+
+        tokio::spawn(async move {
+            liveness_listener(update_recv, liveness_status_clone).await;
+        });
+        tokio::spawn(async move {
+            liveness_request_processor(request_recv, liveness_status).await;
+        });
+
+        // Send updates
+        update_snd
+            .send(LiveReadyUpdate::Readiness(ReadinessState::Ready))
+            .await
+            .unwrap();
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Unhealthy))
+            .await
+            .unwrap();
+
+        // Request status immediately after sending updates
+        let (response_tx, response_rx) = oneshot::channel();
+        request_snd.send(response_tx).await.unwrap();
+
+        // Ensure the status reflects the last update sent
+        let received_status = response_rx.await.expect("Failed to receive response");
+        assert_eq!(received_status.readiness, ReadinessState::Ready);
+        assert_eq!(received_status.health, HealthState::Unhealthy);
+
+        // Send another set of updates and request again
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Healthy))
+            .await
+            .unwrap();
+        let (new_response_tx, new_response_rx) = oneshot::channel();
+        request_snd.send(new_response_tx).await.unwrap();
+
+        let new_received_status = new_response_rx
+            .await
+            .expect("Failed to receive new response");
+        assert_eq!(new_received_status.health, HealthState::Healthy);
+
+        // Testing edge cases
+        // Sending None update (Shouldn't change the status)
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Healthy))
+            .await
+            .unwrap();
+        let (edge_response_tx, edge_response_rx) = oneshot::channel();
+        request_snd.send(edge_response_tx).await.unwrap();
+
+        let edge_received_status = edge_response_rx
+            .await
+            .expect("Failed to receive edge response");
+        assert_eq!(edge_received_status.readiness, ReadinessState::Ready);
+        assert_eq!(edge_received_status.health, HealthState::Healthy);
+    }
+
+    #[tokio::test]
+    async fn test_empty_updates_does_not_change_status() {
+        let (update_snd, update_recv) = mpsc::channel(1);
+        let liveness_status = Arc::new(RwLock::new(LiveReady {
+            readiness: ReadinessState::Ready,
+            health: HealthState::Healthy,
+        }));
+
+        let liveness_status_clone = liveness_status.clone();
+
+        tokio::spawn(async move {
+            liveness_listener(update_recv, liveness_status_clone).await;
+        });
+
+        // Intentionally not sending any updates
+        drop(update_snd);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await; // Give time for any potential updates
+
+        assert_eq!(
+            liveness_status.read().unwrap().readiness,
+            ReadinessState::Ready
+        );
+        assert_eq!(liveness_status.read().unwrap().health, HealthState::Healthy);
+    }
+
+    #[tokio::test]
+    async fn test_health_state_transitions() {
+        let rpc_list = Arc::new(RwLock::new(vec![Rpc::default(), Rpc::default()]));
+        let poverty_list = Arc::new(RwLock::new(Vec::new()));
+        let (update_snd, update_recv) = mpsc::channel(10);
+        let liveness_status = Arc::new(RwLock::new(LiveReady::default()));
+
+        let liveness_status_clone = liveness_status.clone();
+
+        tokio::spawn(async move {
+            liveness_listener(update_recv, liveness_status_clone).await;
+        });
+
+        // Force add RPCs to poverty list and send health update
+        let mut rpcs_in_poverty = rpc_list.write().unwrap().drain(..).collect::<Vec<_>>();
+        poverty_list.write().unwrap().append(&mut rpcs_in_poverty);
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Unhealthy))
+            .await
+            .unwrap();
+
+        // Check for Unhealthy status
+        sleep(Duration::from_millis(50)).await; // Allow for processing
+        assert_eq!(
+            liveness_status.read().unwrap().health,
+            HealthState::Unhealthy
+        );
+        assert!(rpc_list.read().unwrap().is_empty());
+        assert_eq!(poverty_list.read().unwrap().len(), 2);
+
+        // Remove RPCs from poverty list, simulate recovery, and send health update
+        let mut recovered_rpcs = poverty_list.write().unwrap().drain(..).collect::<Vec<_>>();
+        rpc_list.write().unwrap().append(&mut recovered_rpcs);
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Healthy))
+            .await
+            .unwrap();
+
+        // Check for Healthy status
+        sleep(Duration::from_millis(50)).await; // Allow for processing
+        assert_eq!(liveness_status.read().unwrap().health, HealthState::Healthy);
+        assert_eq!(rpc_list.read().unwrap().len(), 2);
+        assert!(poverty_list.read().unwrap().is_empty());
+
+        // Reverse the process: simulate RPCs failing again and moving back to poverty list
+        let mut rpcs_in_poverty_again = rpc_list.write().unwrap().drain(..).collect::<Vec<_>>();
+        poverty_list
+            .write()
+            .unwrap()
+            .append(&mut rpcs_in_poverty_again);
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Unhealthy))
+            .await
+            .unwrap();
+
+        // Check for Unhealthy status again
+        sleep(Duration::from_millis(50)).await; // Allow for processing
+        assert_eq!(
+            liveness_status.read().unwrap().health,
+            HealthState::Unhealthy
+        );
+        assert!(rpc_list.read().unwrap().is_empty());
+        assert_eq!(poverty_list.read().unwrap().len(), 2);
+
+        // Recover again and verify
+        let mut recovered_rpcs_again = poverty_list.write().unwrap().drain(..).collect::<Vec<_>>();
+        rpc_list.write().unwrap().append(&mut recovered_rpcs_again);
+        update_snd
+            .send(LiveReadyUpdate::Health(HealthState::Healthy))
+            .await
+            .unwrap();
+
+        // Final check for Healthy status
+        sleep(Duration::from_millis(50)).await; // Allow for processing
+        assert_eq!(liveness_status.read().unwrap().health, HealthState::Healthy);
+        assert_eq!(rpc_list.read().unwrap().len(), 2);
+        assert!(poverty_list.read().unwrap().is_empty());
+    }
+}

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -1,4 +1,5 @@
 mod accept;
 mod error;
 pub mod listener;
+pub mod liveready;
 mod methods;

--- a/src/balancer/accept_http.rs
+++ b/src/balancer/accept_http.rs
@@ -201,14 +201,38 @@ macro_rules! get_response {
                 // a node for a proper response.
                 if cached["method"] == Value::Null {
                     let _ = $cache.remove($tx_hash.as_bytes());
-                    fetch_from_rpc!($tx, $id, $rpc_list_rwlock, $rpc_position, $cache, $tx_hash, $finalized_rx, $named_numbers, $head_cache, $ttl, $max_retries)
+                    fetch_from_rpc!(
+                        $tx,
+                        $id,
+                        $rpc_list_rwlock,
+                        $rpc_position,
+                        $cache,
+                        $tx_hash,
+                        $finalized_rx,
+                        $named_numbers,
+                        $head_cache,
+                        $ttl,
+                        $max_retries
+                    )
                 } else {
                     cached["id"] = $id.into();
                     cached.to_string()
                 }
-            },
+            }
             Ok(None) => {
-                fetch_from_rpc!($tx, $id, $rpc_list_rwlock, $rpc_position, $cache, $tx_hash, $finalized_rx, $named_numbers, $head_cache, $ttl, $max_retries)
+                fetch_from_rpc!(
+                    $tx,
+                    $id,
+                    $rpc_list_rwlock,
+                    $rpc_position,
+                    $cache,
+                    $tx_hash,
+                    $finalized_rx,
+                    $named_numbers,
+                    $head_cache,
+                    $ttl,
+                    $max_retries
+                )
             }
             Err(_) => {
                 // If anything errors send an rpc request and see if it works, if not then gg

--- a/src/balancer/accept_http.rs
+++ b/src/balancer/accept_http.rs
@@ -44,6 +44,8 @@ use serde_json::Value;
 #[cfg(not(feature = "xxhash"))]
 use blake3::hash;
 
+use memchr::memmem;
+
 #[cfg(feature = "xxhash")]
 use xxhash_rust::xxh3::xxh3_64;
 #[cfg(feature = "xxhash")]
@@ -199,7 +201,7 @@ macro_rules! get_response {
                 //
                 // If a cached response returns null, remove it from the DB and querry
                 // a node for a proper response.
-                if cached["method"] == Value::Null {
+                if memmem::find(&rax, "null}".as_bytes()).is_some() {
                     let _ = $cache.remove($tx_hash.as_bytes());
                     fetch_from_rpc!(
                         $tx,

--- a/src/balancer/accept_http.rs
+++ b/src/balancer/accept_http.rs
@@ -223,7 +223,19 @@ macro_rules! get_response {
 }
 
 macro_rules! fetch_from_rpc {
-    ($tx:expr, $id:expr, $rpc_list_rwlock:expr, $rpc_position:expr, $cache:expr, $tx_hash:expr, $finalized_rx:expr, $named_numbers:expr, $head_cache:expr, $ttl:expr, $max_retries:expr) => {{
+    (
+        $tx:expr,
+        $id:expr,
+        $rpc_list_rwlock:expr,
+        $rpc_position:expr,
+        $cache:expr,
+        $tx_hash:expr,
+        $finalized_rx:expr,
+        $named_numbers:expr,
+        $head_cache:expr,
+        $ttl:expr,
+        $max_retries:expr
+    ) => {{
         // Kinda jank but set the id back to what it was before
         $tx["id"] = $id.into();
 

--- a/src/balancer/accept_http.rs
+++ b/src/balancer/accept_http.rs
@@ -194,71 +194,21 @@ macro_rules! get_response {
                 // Reconstruct ID
                 let mut cached: Value = simd_json::serde::from_slice(&mut rax).unwrap();
 
-                cached["id"] = $id.into();
-                cached.to_string()
+                // TODO: This is a temp fix to mitigate DB corruption issues.
+                // This worsens performance by quite a bit and should not be left as is.
+                //
+                // If a cached response returns null, remove it from the DB and querry
+                // a node for a proper response.
+                if cached["method"] == Value::Null {
+                    let _ = $cache.remove($tx_hash.as_bytes());
+                    fetch_from_rpc!($tx, $id, $rpc_list_rwlock, $rpc_position, $cache, $tx_hash, $finalized_rx, $named_numbers, $head_cache, $ttl, $max_retries)
+                } else {
+                    cached["id"] = $id.into();
+                    cached.to_string()
+                }
             },
             Ok(None) => {
-                // Kinda jank but set the id back to what it was before
-                $tx["id"] = $id.into();
-
-                // Loop until we get a response
-                let mut rx;
-                let mut retries = 0;
-                loop {
-                    // Get the next Rpc in line.
-                    let mut rpc;
-                    {
-                        let mut rpc_list = $rpc_list_rwlock.write().unwrap();
-                        (rpc, $rpc_position) = pick(&mut rpc_list);
-                    }
-                    log_info!("Forwarding to: {}", rpc.name);
-
-                    // Check if we have any RPCs in the list, if not return error
-                    if $rpc_position == None {
-                        return (no_rpc_available!(), None);
-                    }
-
-                    // Send the request. And return a timeout if it takes too long
-                    //
-                    // Check if it contains any errors or if its `latest` and insert it if it isn't
-                    match timeout(
-                        Duration::from_millis($ttl.try_into().unwrap()),
-                        rpc.send_request($tx.clone()),
-                    )
-                    .await
-                    {
-                        Ok(rxa) => {
-                            rx = rxa.unwrap();
-                            break;
-                        },
-                        Err(_) => {
-                            log_wrn!("\x1b[93mWrn:\x1b[0m An RPC request has timed out, picking new RPC and retrying.");
-                            rpc.update_latency($ttl as f64);
-                            retries += 1;
-                        },
-                    };
-
-                    if retries == $max_retries {
-                        return (timed_out!(), $rpc_position,);
-                    }
-                }
-
-                let cache_args = CacheArgs {
-                    finalized_rx: $finalized_rx,
-                    named_numbers: $named_numbers,
-                    cache: $cache,
-                    head_cache: $head_cache,
-                };
-
-                // Don't cache responses that contain errors or missing trie nodes
-                cache_querry(
-                    &mut rx,
-                    $tx,
-                    $tx_hash,
-                    &cache_args,
-                );
-
-                rx
+                fetch_from_rpc!($tx, $id, $rpc_list_rwlock, $rpc_position, $cache, $tx_hash, $finalized_rx, $named_numbers, $head_cache, $ttl, $max_retries)
             }
             Err(_) => {
                 // If anything errors send an rpc request and see if it works, if not then gg
@@ -268,6 +218,72 @@ macro_rules! get_response {
             }
         }
     };
+}
+
+macro_rules! fetch_from_rpc {
+    ($tx:expr, $id:expr, $rpc_list_rwlock:expr, $rpc_position:expr, $cache:expr, $tx_hash:expr, $finalized_rx:expr, $named_numbers:expr, $head_cache:expr, $ttl:expr, $max_retries:expr) => {{
+        // Kinda jank but set the id back to what it was before
+        $tx["id"] = $id.into();
+
+        // Loop until we get a response
+        let mut rx;
+        let mut retries = 0;
+        loop {
+            // Get the next Rpc in line.
+            let mut rpc;
+            {
+                let mut rpc_list = $rpc_list_rwlock.write().unwrap();
+                (rpc, $rpc_position) = pick(&mut rpc_list);
+            }
+            log_info!("Forwarding to: {}", rpc.name);
+
+            // Check if we have any RPCs in the list, if not return error
+            if $rpc_position == None {
+                return (no_rpc_available!(), None);
+            }
+
+            // Send the request. And return a timeout if it takes too long
+            //
+            // Check if it contains any errors or if its `latest` and insert it if it isn't
+            match timeout(
+                Duration::from_millis($ttl.try_into().unwrap()),
+                rpc.send_request($tx.clone()),
+            )
+            .await
+            {
+                Ok(rxa) => {
+                    rx = rxa.unwrap();
+                    break;
+                },
+                Err(_) => {
+                    log_wrn!("\x1b[93mWrn:\x1b[0m An RPC request has timed out, picking new RPC and retrying.");
+                    rpc.update_latency($ttl as f64);
+                    retries += 1;
+                },
+            };
+
+            if retries == $max_retries {
+                return (timed_out!(), $rpc_position,);
+            }
+        }
+
+        let cache_args = CacheArgs {
+            finalized_rx: $finalized_rx,
+            named_numbers: $named_numbers,
+            cache: $cache,
+            head_cache: $head_cache,
+        };
+
+        // Don't cache responses that contain errors or missing trie nodes
+        cache_querry(
+            &mut rx,
+            $tx,
+            $tx_hash,
+            &cache_args,
+        );
+
+        rx
+    }};
 }
 
 // Pick RPC and send request to it. In case the result is cached,

--- a/src/balancer/selection/cache_rules.rs
+++ b/src/balancer/selection/cache_rules.rs
@@ -10,7 +10,6 @@ pub fn cache_method(rx: &str) -> bool {
     return false;
 
     // all of the below cannot be cached properly
-    // `null` should never be in a proper request
     let blacklist = [
         "latest",
         "eth_blockNumber",
@@ -20,7 +19,6 @@ pub fn cache_method(rx: &str) -> bool {
         "pending",
         "eth_subscribe",
         "eth_unsubscribe",
-        "null",
     ];
     // rx should look something like `{"id":1,"jsonrpc":"2.0","method":"eth_call","params":...`
     // Even tho rx should look like the example above, its still a valid request if the method

--- a/src/balancer/selection/select.rs
+++ b/src/balancer/selection/select.rs
@@ -2,7 +2,7 @@ use crate::Rpc;
 use std::time::SystemTime;
 
 // Generic entry point fn to select the next rpc and return its position
-pub fn pick(list: &mut Vec<Rpc>) -> (Rpc, Option<usize>) {
+pub fn pick(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
     // If len is 1, return the only element
     if list.len() == 1 {
         return (list[0].clone(), Some(0));
@@ -35,7 +35,7 @@ pub fn argsort(data: &[Rpc]) -> Vec<usize> {
     not(feature = "selection-random"),
     not(feature = "old-weighted-round-robin"),
 ))]
-fn algo(list: &mut Vec<Rpc>) -> (Rpc, Option<usize>) {
+fn algo(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
     // Sort by latency
     let indices = argsort(list);
 
@@ -84,7 +84,7 @@ fn algo(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
     feature = "selection-weighed-round-robin",
     feature = "old-weighted-round-robin",
 ))]
-fn algo(list: &mut Vec<Rpc>) -> (Rpc, Option<usize>) {
+fn algo(list: &mut [Rpc]) -> (Rpc, Option<usize>) {
     // Sort by latency
     let indices = argsort(list);
 

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -4,7 +4,7 @@ pub const WS_SUB_MANAGER_ID: u32 = 2;
 pub const MAGIC: u32 = 0xb153;
 
 // Version consts, dont impact functionality
-pub const VERSION_STR: &str = "Blutgang 0.3.3 Garreg Mach";
+pub const VERSION_STR: &str = "Blutgang 0.3.3-rc1 Garreg Mach";
 pub const TAGLINE: &str = "`Now there's a way forward.`";
 
 #[cfg(feature = "journald")]

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -4,7 +4,7 @@ pub const WS_SUB_MANAGER_ID: u32 = 2;
 pub const MAGIC: u32 = 0xb153;
 
 // Version consts, dont impact functionality
-pub const VERSION_STR: &str = "Blutgang 0.3.2 Garreg Mach";
+pub const VERSION_STR: &str = "Blutgang 0.3.3 Garreg Mach";
 pub const TAGLINE: &str = "`Now there's a way forward.`";
 
 #[cfg(feature = "journald")]
@@ -19,7 +19,7 @@ macro_rules! log_info {
         let message = format!($fmt, $($arg)*);
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(6, &message);
         }
         println!("\x1b[35mInfo:\x1b[0m {}", message)
@@ -27,7 +27,7 @@ macro_rules! log_info {
     ($fmt:expr) => {
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(6, $fmt);
         }
         println!(concat!("\x1b[35mInfo:\x1b[0m ", $fmt))
@@ -40,7 +40,7 @@ macro_rules! log_wrn {
         let message = format!($fmt, $($arg)*);
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(4, &message);
         }
         println!("\x1b[93mWrn:\x1b[0m {}", message)
@@ -48,7 +48,7 @@ macro_rules! log_wrn {
     ($fmt:expr) => {
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(4, $fmt);
         }
         println!(concat!("\x1b[93mWrn:\x1b[0m ", $fmt))
@@ -61,7 +61,7 @@ macro_rules! log_err {
         let message = format!($fmt, $($arg)*);
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(3, &message);
         }
         println!("\x1b[31mErr:\x1b[0m {}", message)
@@ -69,7 +69,7 @@ macro_rules! log_err {
     ($fmt:expr) => {
         #[cfg(feature = "journald")]
         {
-            use crate::config::system::log_journald;
+            use $crate::config::system::log_journald;
             log_journald(3, $fmt);
         }
         println!(concat!("\x1b[31mErr:\x1b[0m ", $fmt))

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -4,7 +4,7 @@ pub const WS_SUB_MANAGER_ID: u32 = 2;
 pub const MAGIC: u32 = 0xb153;
 
 // Version consts, dont impact functionality
-pub const VERSION_STR: &str = "Blutgang 0.3.3-rc1 Garreg Mach";
+pub const VERSION_STR: &str = "Blutgang 0.3.3-rc2 Garreg Mach";
 pub const TAGLINE: &str = "`Now there's a way forward.`";
 
 #[cfg(feature = "journald")]

--- a/src/config/system.rs
+++ b/src/config/system.rs
@@ -4,7 +4,7 @@ pub const WS_SUB_MANAGER_ID: u32 = 2;
 pub const MAGIC: u32 = 0xb153;
 
 // Version consts, dont impact functionality
-pub const VERSION_STR: &str = "Blutgang 0.3.3-rc2 Garreg Mach";
+pub const VERSION_STR: &str = "Blutgang 0.3.3 Garreg Mach";
 pub const TAGLINE: &str = "`Now there's a way forward.`";
 
 #[cfg(feature = "journald")]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -59,6 +59,7 @@ impl Debug for AdminSettings {
 #[derive(Debug, Clone)]
 pub struct Settings {
     pub rpc_list: Vec<Rpc>,
+    pub poverty_list: Vec<Rpc>,
     pub is_ws: bool,
     pub do_clear: bool,
     pub address: SocketAddr,
@@ -76,6 +77,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             rpc_list: Vec::new(),
+            poverty_list: Vec::new(),
             is_ws: true,
             do_clear: false,
             address: "127.0.0.1:3000".parse::<SocketAddr>().unwrap(),
@@ -386,9 +388,10 @@ impl Settings {
             }
         };
 
+        let mut poverty_list = Vec::new();
         if sort_on_startup {
             println!("Sorting RPCs by latency...");
-            rpc_list = match sort_by_latency(rpc_list, ma_length).await {
+            (rpc_list, poverty_list) = match sort_by_latency(rpc_list, poverty_list, ma_length).await {
                 Ok(rax) => rax,
                 Err(e) => {
                     panic!("{:?}", e);
@@ -398,6 +401,7 @@ impl Settings {
 
         Settings {
             rpc_list,
+            poverty_list,
             is_ws,
             do_clear,
             address,
@@ -545,6 +549,7 @@ impl Settings {
 
         Settings {
             rpc_list,
+            poverty_list: Vec::new(),
             is_ws: false,
             do_clear: clear,
             address,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -64,6 +64,7 @@ pub struct Settings {
     pub do_clear: bool,
     pub address: SocketAddr,
     pub health_check: bool,
+    pub header_check: bool,
     pub ttl: u128,
     pub expected_block_time: u64,
     pub supress_rpc_check: bool,
@@ -82,6 +83,7 @@ impl Default for Settings {
             do_clear: false,
             address: "127.0.0.1:3000".parse::<SocketAddr>().unwrap(),
             health_check: false,
+            header_check: true,
             ttl: 1000,
             expected_block_time: 12500,
             supress_rpc_check: true,
@@ -169,6 +171,11 @@ impl Settings {
             .expect("\x1b[31mErr:\x1b[0m Missing health_check toggle!")
             .as_bool()
             .expect("\x1b[31mErr:\x1b[0m Could not parse health_check as bool!");
+        let header_check = blutgang_table
+            .get("header_check")
+            .expect("\x1b[31mErr:\x1b[0m Missing header_check toggle!")
+            .as_bool()
+            .expect("\x1b[31mErr:\x1b[0m Could not parse header_check as bool!");
         let ttl = blutgang_table
             .get("ttl")
             .expect("\x1b[31mErr:\x1b[0m Missing ttl!")
@@ -406,6 +413,7 @@ impl Settings {
             do_clear,
             address,
             health_check,
+            header_check,
             ttl,
             expected_block_time,
             max_retries,
@@ -494,6 +502,7 @@ impl Settings {
             .flush_every_ms(Some(flush_every_ms));
 
         let health_check = matches.get_occurrences::<String>("health_check").is_some();
+        let header_check = matches.get_occurrences::<String>("header_check").is_some();
 
         let ttl = matches
             .get_one::<String>("ttl")
@@ -554,6 +563,7 @@ impl Settings {
             do_clear: clear,
             address,
             health_check,
+            header_check,
             ttl,
             supress_rpc_check,
             expected_block_time,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -398,12 +398,13 @@ impl Settings {
         let mut poverty_list = Vec::new();
         if sort_on_startup {
             println!("Sorting RPCs by latency...");
-            (rpc_list, poverty_list) = match sort_by_latency(rpc_list, poverty_list, ma_length).await {
-                Ok(rax) => rax,
-                Err(e) => {
-                    panic!("{:?}", e);
-                }
-            };
+            (rpc_list, poverty_list) =
+                match sort_by_latency(rpc_list, poverty_list, ma_length).await {
+                    Ok(rax) => rax,
+                    Err(e) => {
+                        panic!("{:?}", e);
+                    }
+                };
         }
 
         Settings {

--- a/src/health/safe_block.rs
+++ b/src/health/safe_block.rs
@@ -99,7 +99,7 @@ pub async fn get_safe_block(
             let reported_finalized = match result {
                 Ok(Ok(response)) => response,
                 Err(_) => 0,
-                Ok(Err(_)) => 0,                 
+                Ok(Err(_)) => 0,
             };
 
             // Send the result to the main thread through the channel

--- a/src/health/safe_block.rs
+++ b/src/health/safe_block.rs
@@ -95,9 +95,11 @@ pub async fn get_safe_block(
             let a = rpc_clone.get_finalized_block();
             let result = timeout(Duration::from_millis(ttl), a).await;
 
+            // Handle timeout as 0
             let reported_finalized = match result {
-                Ok(response) => response.unwrap(), // Handle timeout as 0
-                Err(_) => 0,                       // Handle timeout as 0
+                Ok(Ok(response)) => response,
+                Err(_) => 0,
+                Ok(Err(_)) => 0,                 
             };
 
             // Send the result to the main thread through the channel

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -45,7 +45,7 @@ pub struct Rpc {
 // For example, if we have a URL: https://eth-mainnet.g.alchemy.com/v2/api-key
 // as input, we output: https://eth-mainnet.g.alchemy.com/
 fn sanitize_url(url: &str) -> Result<String, url::ParseError> {
-    let parsed_url = Url::parse(&url)?;
+    let parsed_url = Url::parse(url)?;
 
     // Build a new URL with the scheme, host, and port (if any), but without the path or query
     let sanitized = Url::parse(&format!(

--- a/src/websocket/client.rs
+++ b/src/websocket/client.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     log_err,
     log_info,
-    log_wrn,
     rpc::types::Rpc,
     websocket::{
         error::WsError,
@@ -197,8 +196,10 @@ pub async fn ws_conn(
 
                     let rax = match unsafe { from_str(&mut ws_message) } {
                         Ok(rax) => rax,
-                        Err(e) => {
-                            log_wrn!("Couldn't deserialize ws_conn response: {}", e);
+                        Err(_e) => {
+                            #[cfg(feature = "debug-verbose")]
+                            log_wrn!("Couldn't deserialize ws_conn response: {}", _e);
+
                             continue;
                         }
                     };


### PR DESCRIPTION
Minor release:
- Adds proper kubernetes liveness checks, consult the docs for more info.
- Make some warnings less aggressive.
- Blutgang will now gracefully handle nodes dropping connection.
- RPCs that pass url validation, but fail when querried on initial startup will now be added to the `poverty_list` (misbehaving RPC list), and queried later to check if their back up.
- Misc Nix flake improvements.
- Optional header content-type checking. (@rarecrumb)