### PR TITLE
feat: add automatic docker image builder for releases

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,51 @@
+name: Build docker image
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+jobs:
+  build-push:
+    name: build-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Context for Buildx
+        shell: bash
+        id: buildx-context
+        run: |
+          docker context create builders
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          endpoint: builders
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: rainshowerlabs/blutgang
+          flavor: latest=true
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: docker-build-push
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,51 +1,58 @@
 name: Build docker image
+
 on:
   push:
-    branches:
-      - master
     tags:
-      - '**'
+      - '*'
+
 jobs:
+
   build-push:
     name: build-push
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout this repo
-        uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Context for Buildx
-        shell: bash
-        id: buildx-context
-        run: |
-          docker context create builders
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          endpoint: builders
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: rainshowerlabs/blutgang
-          flavor: latest=true
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: docker-build-push
-        id: docker_build
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          push: true
-          platforms: linux/amd64,linux/arm64
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+
+    - name: Checkout this repo
+      uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Context for Buildx
+      shell: bash
+      id: buildx-context
+      run: |
+        docker context create builders
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        endpoint: builders
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: rainshowerlabs/blutgang
+        tags: |
+          type=semver,pattern={{version}}
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: docker-build-push
+      id: docker_build
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: Dockerfile
+        tags: ${{ steps.meta.outputs.tags }}
+        push: true
+        platforms: linux/amd64,linux/arm64
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -2,8 +2,10 @@ name: Build docker image
 
 on:
   push:
+    branches:
+      - master
     tags:
-      - '*'
+      - '**'
 
 jobs:
 
@@ -34,7 +36,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v4
       with:
-        images: rainshowerlabs/blutgang
+        images: makemake1337/blutgang
         tags: |
           type=semver,pattern={{version}}
 


### PR DESCRIPTION
* Create a new account on dockerhub `rainshowerlabs`
* Create a new auth token
* Save the username and token as a secret in the repo under DOCKER_USERNAME and DOCKER_PASSWORD
* Merge this PR
* Make a new release, and see new multiarch image built/pushed to `rainshowerlabs/blutgang:<version>`