### PR TITLE
Db arc removal

### DIFF
--- a/src/admin/accept.rs
+++ b/src/admin/accept.rs
@@ -204,9 +204,9 @@ mod tests {
     // Helper function to create a test cache
     fn create_test_cache() -> Db {
         let db = sled::Config::new().temporary(true);
-        let db = db.open().unwrap();
+        
 
-        db
+        db.open().unwrap()
     }
 
     #[tokio::test]

--- a/src/admin/accept.rs
+++ b/src/admin/accept.rs
@@ -82,7 +82,7 @@ macro_rules! get_response {
             $rpc_list_rwlock,
             $poverty_list_rwlock,
             Arc::clone(&$config),
-            Arc::clone(&$cache),
+            $cache.clone(),
         ).await {
             Ok(rx) => rx,
             Err(err) => json!({
@@ -106,7 +106,7 @@ async fn forward_body(
     mut tx: Value,
     rpc_list_rwlock: &Arc<RwLock<Vec<Rpc>>>,
     poverty_list_rwlock: &Arc<RwLock<Vec<Rpc>>>,
-    cache: Arc<Db>,
+    cache: Db,
     config: Arc<RwLock<Settings>>,
 ) -> Result<hyper::Response<Full<Bytes>>, Infallible> {
     // Get the id of the request and set it to 0 for caching
@@ -136,7 +136,7 @@ pub async fn accept_admin_request(
     tx: Request<hyper::body::Incoming>,
     rpc_list_rwlock: Arc<RwLock<Vec<Rpc>>>,
     poverty_list_rwlock: Arc<RwLock<Vec<Rpc>>>,
-    cache: Arc<Db>,
+    cache: Db,
     config: Arc<RwLock<Settings>>,
     liveness_request_tx: LiveReadyRequestSnd,
 ) -> Result<hyper::Response<Full<Bytes>>, Infallible> {
@@ -202,11 +202,11 @@ mod tests {
     }
 
     // Helper function to create a test cache
-    fn create_test_cache() -> Arc<Db> {
+    fn create_test_cache() -> Db {
         let db = sled::Config::new().temporary(true);
         let db = db.open().unwrap();
 
-        Arc::new(db)
+        db
     }
 
     #[tokio::test]

--- a/src/admin/listener.rs
+++ b/src/admin/listener.rs
@@ -51,7 +51,7 @@ macro_rules! accept_admin {
                         req,
                         Arc::clone($rpc_list_rwlock),
                         Arc::clone($poverty_list_rwlock),
-                        Arc::clone($cache),
+                        $cache.clone(),
                         Arc::clone($config),
                         $liveness_request_tx.clone(),
                     );
@@ -68,7 +68,7 @@ macro_rules! accept_admin {
 async fn admin_api_server(
     rpc_list_rwlock: Arc<RwLock<Vec<Rpc>>>,
     poverty_list_rwlock: Arc<RwLock<Vec<Rpc>>>,
-    cache: Arc<Db>,
+    cache: Db,
     config: Arc<RwLock<Settings>>,
     address: SocketAddr,
     liveness_request_tx: LiveReadyRequestSnd,
@@ -87,7 +87,7 @@ async fn admin_api_server(
 
         let rpc_list_rwlock_clone = Arc::clone(&rpc_list_rwlock);
         let poverty_list_rwlock_clone = Arc::clone(&poverty_list_rwlock);
-        let cache_clone = Arc::clone(&cache);
+        let cache_clone = cache.clone();
         let config_clone = Arc::clone(&config);
         let liveness_request_tx_clone = liveness_request_tx.clone();
 
@@ -112,7 +112,7 @@ async fn admin_api_server(
 pub async fn listen_for_admin_requests(
     rpc_list_rwlock: Arc<RwLock<Vec<Rpc>>>,
     poverty_list_rwlock: Arc<RwLock<Vec<Rpc>>>,
-    cache: Arc<Db>,
+    cache: Db,
     config: Arc<RwLock<Settings>>,
     liveness_receiver: LiveReadyUpdateRecv,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/admin/methods.rs
+++ b/src/admin/methods.rs
@@ -429,9 +429,9 @@ mod tests {
     // Helper function to create a test cache
     fn create_test_cache() -> Db {
         let db = sled::Config::new().temporary(true);
-        let db = db.open().unwrap();
+        
 
-        db
+        db.open().unwrap()
     }
 
     #[tokio::test]

--- a/src/admin/methods.rs
+++ b/src/admin/methods.rs
@@ -26,7 +26,7 @@ pub async fn execute_method(
     rpc_list: &Arc<RwLock<Vec<Rpc>>>,
     poverty_list: &Arc<RwLock<Vec<Rpc>>>,
     config: Arc<RwLock<Settings>>,
-    cache: Arc<Db>,
+    cache: Db,
 ) -> Result<Value, AdminError> {
     let method = tx["method"].as_str();
     println!("Method: {:?}", method.unwrap_or("None"));
@@ -104,7 +104,7 @@ pub async fn execute_method(
 // Quit Blutgang upon receiving this method
 // We're returning a Null and allowing unreachable code so rustc doesnt cry
 #[allow(unreachable_code)]
-async fn admin_blutgang_quit(cache: Arc<Db>) -> Result<Value, AdminError> {
+async fn admin_blutgang_quit(cache: Db) -> Result<Value, AdminError> {
     // We're doing something not-good so flush everything to disk
     let _ = cache.flush_async().await;
     // Drop cache so we get the print profile on drop thing before we quit
@@ -118,7 +118,7 @@ async fn admin_blutgang_quit(cache: Arc<Db>) -> Result<Value, AdminError> {
 }
 
 // Flushes sled cache to disk
-async fn admin_flush_cache(cache: Arc<Db>) -> Result<Value, AdminError> {
+async fn admin_flush_cache(cache: Db) -> Result<Value, AdminError> {
     let time = Instant::now();
     let _ = cache.flush_async().await;
     let time = time.elapsed();
@@ -427,11 +427,11 @@ mod tests {
     }
 
     // Helper function to create a test cache
-    fn create_test_cache() -> Arc<Db> {
+    fn create_test_cache() -> Db {
         let db = sled::Config::new().temporary(true);
         let db = db.open().unwrap();
 
-        Arc::new(db)
+        db
     }
 
     #[tokio::test]

--- a/src/balancer/accept_http.rs
+++ b/src/balancer/accept_http.rs
@@ -85,7 +85,7 @@ pub struct ConnectionParams {
     pub named_numbers: Arc<RwLock<NamedBlocknumbers>>,
     pub head_cache: Arc<RwLock<BTreeMap<u64, Vec<String>>>>,
     pub sub_data: Arc<SubscriptionData>,
-    pub cache: Arc<Db>,
+    pub cache: Db,
     pub config: Arc<RwLock<Settings>>,
 }
 
@@ -96,7 +96,7 @@ impl ConnectionParams {
         named_numbers: &Arc<RwLock<NamedBlocknumbers>>,
         head_cache: &Arc<RwLock<BTreeMap<u64, Vec<String>>>>,
         sub_data: &Arc<SubscriptionData>,
-        cache: &Arc<Db>,
+        cache: Db,
         config: &Arc<RwLock<Settings>>,
     ) -> Self {
         ConnectionParams {
@@ -308,7 +308,7 @@ async fn forward_body(
     finalized_rx: &watch::Receiver<u64>,
     named_numbers: &Arc<RwLock<NamedBlocknumbers>>,
     head_cache: &Arc<RwLock<BTreeMap<u64, Vec<String>>>>,
-    cache: Arc<Db>,
+    cache: Db,
     params: RequestParams,
 ) -> (
     Result<hyper::Response<Full<Bytes>>, Infallible>,

--- a/src/balancer/accept_http.rs
+++ b/src/balancer/accept_http.rs
@@ -317,16 +317,14 @@ async fn forward_body(
     // Check if body has application/json
     //
     // Can be toggled via the config. Should be on if we want blutgang to be JSON-RPC compliant.
-    if params.header_check {
-        if tx.headers().get("content-type") != Some(&HeaderValue::from_static("application/json")) {
-            return (
-                Ok(hyper::Response::builder()
-                    .status(400)
-                    .body(Full::new(Bytes::from("Improper content-type header")))
-                    .unwrap()),
-                None,
-            );
-        }
+    if params.header_check && tx.headers().get("content-type") != Some(&HeaderValue::from_static("application/json")) {
+        return (
+            Ok(hyper::Response::builder()
+                .status(400)
+                .body(Full::new(Bytes::from("Improper content-type header")))
+                .unwrap()),
+            None,
+        );
     }
 
     // Convert incoming body to serde value

--- a/src/balancer/processing.rs
+++ b/src/balancer/processing.rs
@@ -31,7 +31,7 @@ use sled::Db;
 pub struct CacheArgs {
     pub finalized_rx: watch::Receiver<u64>,
     pub named_numbers: Arc<RwLock<NamedBlocknumbers>>,
-    pub cache: Arc<Db>,
+    pub cache: Db,
     pub head_cache: Arc<RwLock<BTreeMap<u64, Vec<String>>>>,
 }
 
@@ -41,7 +41,7 @@ impl CacheArgs {
         CacheArgs {
             finalized_rx: watch::channel(0).1,
             named_numbers: Arc::new(RwLock::new(NamedBlocknumbers::default())),
-            cache: Arc::new(sled::Config::default().open().unwrap()),
+            cache: (sled::Config::default().open().unwrap()),
             head_cache: Arc::new(RwLock::new(BTreeMap::new())),
         }
     }

--- a/src/config/cache_setup.rs
+++ b/src/config/cache_setup.rs
@@ -55,4 +55,3 @@ pub fn setup_data(cache: Db) {
         }
     }
 }
-

--- a/src/config/cache_setup.rs
+++ b/src/config/cache_setup.rs
@@ -7,9 +7,8 @@ use crate::{
     log_info,
 };
 use sled::Db;
-use std::sync::Arc;
 
-pub fn setup_data(cache: Arc<Db>) {
+pub fn setup_data(cache: Db) {
     let version_json = format!(
         "{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"{}; {}\"}}",
         VERSION_STR, TAGLINE
@@ -56,3 +55,4 @@ pub fn setup_data(cache: Arc<Db>) {
         }
     }
 }
+

--- a/src/health/check.rs
+++ b/src/health/check.rs
@@ -235,7 +235,7 @@ fn make_poverty(
     let mut poverty_list_guard = poverty_list.write().unwrap();
 
     for head in heads {
-        if head.reported_head < highest_head || head.is_syncing == true {
+        if head.reported_head < highest_head || head.is_syncing {
             // Mark the RPC as erroring
             rpc_list_guard[head.rpc_list_index].status.is_erroring = true;
             log_wrn!(
@@ -268,7 +268,7 @@ fn escape_poverty(
     let mut rpc_list_guard = rpc_list.write().unwrap();
 
     for head_result in poverty_heads {
-        if head_result.reported_head >= agreed_head && head_result.is_syncing == false {
+        if head_result.reported_head >= agreed_head && !head_result.is_syncing {
             let mut rpc = poverty_list_guard[head_result.rpc_list_index].clone();
             rpc.status.is_erroring = false;
             log_info!(

--- a/src/health/head_cache.rs
+++ b/src/health/head_cache.rs
@@ -157,7 +157,7 @@ mod tests {
         }
 
         // Call handle_reorg
-        let result = handle_reorg(&head_cache, 2, 3, cache);
+        let result = handle_reorg(&head_cache, 2, 3, cache.clone());
 
         // Verify the result and check if the data is removed from the cache
         assert!(result.is_ok());

--- a/src/health/head_cache.rs
+++ b/src/health/head_cache.rs
@@ -22,7 +22,7 @@ pub async fn manage_cache(
     head_cache: &Arc<RwLock<BTreeMap<u64, Vec<String>>>>,
     blocknum_rx: tokio::sync::watch::Receiver<u64>,
     finalized_rx: Arc<tokio::sync::watch::Receiver<u64>>,
-    cache: &Arc<sled::Db>,
+    cache: sled::Db,
 ) -> Result<(), sled::Error> {
     let mut block_number = 0;
     let mut last_finalized = 0;
@@ -38,7 +38,7 @@ pub async fn manage_cache(
         // remove everything from the last block to the `new_block`
         if new_block <= block_number {
             log_wrn!("Reorg detected!\nRemoving stale entries from the cache.");
-            handle_reorg(head_cache, block_number, new_block, cache)?;
+            handle_reorg(head_cache, block_number, new_block, cache.clone())?;
         }
 
         // Check if finalized_stream has changed
@@ -61,7 +61,7 @@ fn handle_reorg(
     head_cache: &Arc<RwLock<BTreeMap<u64, Vec<String>>>>,
     block_number: u64,
     new_block: u64,
-    cache: &Arc<sled::Db>,
+    cache: sled::Db,
 ) -> Result<(), sled::Error> {
     // sled batch
     let mut batch = Batch::default();
@@ -142,7 +142,7 @@ mod tests {
     fn test_handle_reorg() {
         // Create test data and resources
         let head_cache = Arc::new(RwLock::new(BTreeMap::new()));
-        let cache = Arc::new(Config::new().temporary(true).open().unwrap());
+        let cache = Config::new().temporary(true).open().unwrap();
 
         let _ = cache.insert("key1", "value1");
         let _ = cache.insert("key2", "value2");
@@ -157,7 +157,7 @@ mod tests {
         }
 
         // Call handle_reorg
-        let result = handle_reorg(&head_cache, 2, 3, &cache);
+        let result = handle_reorg(&head_cache, 2, 3, cache);
 
         // Verify the result and check if the data is removed from the cache
         assert!(result.is_ok());

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,14 +100,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rpc_list_rwlock = Arc::new(RwLock::new(config.read().unwrap().rpc_list.clone()));
 
     // Create/Open sled DB
-    let cache = Arc::new(
+    let cache = 
         config
             .read()
             .unwrap()
             .sled_config
             .open()
-            .expect("Can't open/create database!"),
-    );
+            .expect("Can't open/create database!");
 
     // Cache for storing querries near the tip
     let head_cache = Arc::new(RwLock::new(BTreeMap::<u64, Vec<String>>::new()));
@@ -120,7 +119,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Insert data about blutgang and our settings into the DB
     //
     // Print any relevant warnings about a misconfigured DB. Check docs for more
-    setup_data(Arc::clone(&cache));
+    setup_data(cache.clone());
 
     // We create a TcpListener and bind it to 127.0.0.1:3000
     let listener = TcpListener::bind(addr).await?;
@@ -139,7 +138,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if admin_enabled {
         let rpc_list_admin = Arc::clone(&rpc_list_rwlock);
         let poverty_list_admin = Arc::clone(&rpc_poverty_list);
-        let cache_admin = Arc::clone(&cache);
+        let cache_admin = cache.clone();
         let config_admin = Arc::clone(&config);
         tokio::task::spawn(async move {
             log_info!("Admin namespace enabled, accepting admin methods at admin port");
@@ -160,14 +159,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Spawn a thread for the head cache
     let head_cache_clone = Arc::clone(&head_cache);
-    let cache_clone = Arc::clone(&cache);
+    let cache_clone = cache.clone();
     let finalized_rxclone = Arc::clone(&finalized_rx_arc);
     tokio::task::spawn(async move {
         let _ = manage_cache(
             &head_cache_clone,
             blocknum_rx,
             finalized_rxclone,
-            &cache_clone,
+            cache_clone,
         )
         .await;
     });
@@ -302,7 +301,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &named_blocknumbers,
             &head_cache,
             &sub_data,
-            &cache,
+            cache.clone(),
             &config,
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,13 +100,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rpc_list_rwlock = Arc::new(RwLock::new(config.read().unwrap().rpc_list.clone()));
 
     // Create/Open sled DB
-    let cache = 
-        config
-            .read()
-            .unwrap()
-            .sled_config
-            .open()
-            .expect("Can't open/create database!");
+    let cache = config
+        .read()
+        .unwrap()
+        .sled_config
+        .open()
+        .expect("Can't open/create database!");
 
     // Cache for storing querries near the tip
     let head_cache = Arc::new(RwLock::new(BTreeMap::<u64, Vec<String>>::new()));


### PR DESCRIPTION
Removes redundant `Arc` wrapping for cache db
Feel free to close if this pattern is actually necessary
### Detailed
`sled::Db` already is `Arc`'d internally, and calls to `.clone()` might be a cheaper way for using it
refer to https://docs.rs/sled/latest/sled/struct.Db.html#trait-implementations


### Criterion benchmarks
![Screenshot from 2024-03-29 15-41-49](https://github.com/rainshowerLabs/blutgang/assets/5147364/ce3196ba-f543-4b98-9848-46407709ea71)
![Screenshot from 2024-03-29 15-41-20](https://github.com/rainshowerLabs/blutgang/assets/5147364/c8891e6f-fe79-4ddc-93a8-5547dcc113aa)

