### PR TITLE
Blutgang 0.4.0 Arianrhod

### DIFF
--- a/src/balancer/mod.rs
+++ b/src/balancer/mod.rs
@@ -7,7 +7,6 @@
 //! In addition to this, it includes various helper fn's for formatting
 //! and processing incoming data.
 
-mod pipeline;
 pub mod accept_http;
 pub mod format;
 pub mod processing;

--- a/src/balancer/pipeline.rs
+++ b/src/balancer/pipeline.rs
@@ -1,9 +1,0 @@
-//! The pipeline is responsible for:
-//! - processing raw requests
-//! - sanitizing them
-//! - returning responses
-
-/// The request processor listens for incoming messages 
-pub fn request_processor() {
-
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod health;
 mod rpc;
 mod websocket;
+mod database;
 
 use crate::{
     admin::{


### PR DESCRIPTION
![blutgang_gm](https://github.com/rainshowerLabs/blutgang/assets/55022497/ec668c7a-5f56-4b26-8386-f112c2f176ce)
# Blutgang 0.4.0 Arianrhod
Blutgang 0.4.0 Arianrhod is the next major release of Blutgang.

## Changelog:

todo
