### PR TITLE
🔨 debug scripts

### DIFF
--- a/debug-script/flamegraph
+++ b/debug-script/flamegraph
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+OUTFILE="flamegraph.blutgang.`git describe --always --dirty`-`date +%s`"
+
+CARGO_PROFILE_RELEASE_DEBUG=true \
+cargo flamegraph \
+  --bin=blutgang \
+  -o "${OUTFILE}.svg" \
+  --release   \
+  -- --config example_config.toml
+

--- a/debug-script/flamegraph
+++ b/debug-script/flamegraph
@@ -1,6 +1,19 @@
 #!/bin/sh
 set -e
 
+if [ ! -x "$(command -v perf)" ]
+then
+    echo "Cannot find perf, please make sure it's installed."
+    exit 1
+fi
+
+
+INSTALLED=0
+if [ ! -x "$(command -v cargo-flamegraph)" ]; then
+    echo "cargo-flamegraph not installed; installing ..."
+    cargo install flamegraph
+    INSTALLED=1
+fi
 OUTFILE="flamegraph.blutgang.`git describe --always --dirty`-`date +%s`"
 
 CARGO_PROFILE_RELEASE_DEBUG=true \
@@ -10,3 +23,10 @@ cargo flamegraph \
   --release   \
   -- --config example_config.toml
 
+if [ $INSTALLED == 1 ]; then
+    read -p "Would you like to uninstall cargo-flamegraph? [Y/n] " -n 1 -r
+    echo
+    if [[ "$REPLY" =~ ^[^Nn]*$ ]]; then
+        cargo uninstall flamegraph
+    fi
+fi

--- a/debug-script/instructions
+++ b/debug-script/instructions
@@ -1,0 +1,28 @@
+#!/bin/sh
+# counts instructions for a standard workload
+set -e
+
+OUTFILE="cachegrind.blutgang.`git describe --always --dirty`-`date +%s`"
+
+rm -rf default.sled || true
+
+CARGO_PROFILE_RELEASE_DEBUG=true \
+cargo build \
+  --bin=blutgang \
+  --release   \
+  --config example_config.toml
+
+valgrind \
+  --tool=cachegrind \
+  --cachegrind-out-file=$OUTFILE \
+  timeout 60s ./target/release/blutgang  --config example_config.toml 
+
+LAST=`ls -t cachegrind.stress.* | sed -n 2p`
+
+
+echo "Last cachegrind output: $LAST new file: $OUTFILE"
+
+echo "--------------------------------------------"
+echo "changes in instruction count"
+cg_annotate --diff $LAST $OUTFILE | tail -1
+


### PR DESCRIPTION
Some scripts to hopefully help with debugging 
Includes [flamegraphs](https://brendangregg.com/flamegraphs.html)   and [cachegrind](https://valgrind.org/docs/manual/cg-manual.html#cg-manual.overview) as bash scripts  
These could be merged into existing devshell .nix flakes if needed
the cachegrind script right now is timeouted to 60s and aggregates and diffs across multiple outputs 
flamegraph takes a bit after killing blutgang to write out the svg file